### PR TITLE
chore: reverting e24f80c9b62cfaa0f10429b8ed4136598239ee80

### DIFF
--- a/scripts/ai/strategies/AIDriveStrategyCombineCourse.lua
+++ b/scripts/ai/strategies/AIDriveStrategyCombineCourse.lua
@@ -1494,8 +1494,9 @@ function AIDriveStrategyCombineCourse:handlePipe(dt)
 end
 
 function AIDriveStrategyCombineCourse:handleCombinePipe(dt)
-    -- don't open the pipe while turning
-    if self:isPipeOpenEnabled() and self:isAGoodTrailerInRange() then
+    -- don't open the pipe while turning or driving to self unload
+    -- open it when there's a trailer in range or when AutoDrive wants us to open it
+    if self:isPipeOpenEnabled() and (self:isAGoodTrailerInRange() or self:isAutoDriveWaitingForPipe()) then
         self.pipeController:openPipe()
     else
         if not self.forcePipeOpen:get() then
@@ -1574,6 +1575,12 @@ end
 
 function AIDriveStrategyCombineCourse:getFillLevelPercentage()
     return self.combineController:getFillLevelPercentage()
+end
+
+--- Support for AutoDrive mod: they'll only find us if we open the pipe
+function AIDriveStrategyCombineCourse:isAutoDriveWaitingForPipe()
+    return self.vehicle.spec_autodrive and self.vehicle.spec_autodrive.combineIsCallingDriver and
+            self.vehicle.spec_autodrive:combineIsCallingDriver(self.vehicle)
 end
 
 function AIDriveStrategyCombineCourse:shouldStopForUnloading()


### PR DESCRIPTION
AutoDrive now only tells us to open the pipe when
it has already designated our harvester as the target so hopefully no more unnecessary pipe opening anymore.