### PR TITLE
80 combine mode fails with no path after one run

### DIFF
--- a/scripts/Course.lua
+++ b/scripts/Course.lua
@@ -965,7 +965,8 @@ end
 ---@param reverse boolean is this a reverse course?
 function Course.createFromNode(vehicle, referenceNode, xOffset, from, to, step, reverse)
     local waypoints = {}
-    local distance = math.abs(from - to)
+    -- never go under 0.5 m length, also protect from division by zero when from == to
+    local distance = math.max(math.abs(from - to), 0.5)
     -- if the distance < step, reduce step to the distance, so we have at least two waypoints.
     local nPoints = math.floor(distance / math.min(distance, math.abs(step))) + 1
     local dBetweenPoints = (to - from) / (nPoints - 1)

--- a/scripts/ai/CollisionAvoidanceController.lua
+++ b/scripts/ai/CollisionAvoidanceController.lua
@@ -69,7 +69,7 @@ function CollisionAvoidanceController:findPotentialCollisions()
                     -- for our own ETE, we always use the field speed and not the actual speed. This is to make sure
                     -- we come to a full stop on a warning and remain stopped while the warning is active
                     local myEte = myDistanceToCollision / (self.strategy:getFieldSpeed())
-                    local otherEte = otherDistanceToCollision / (vehicle.lastSpeedReal * 1000)
+                    local otherEte = CpMathUtil.divide(otherDistanceToCollision, (vehicle.lastSpeedReal * 1000))
                     -- self:debug('Checking %s at %.1f m, %.1f, ETE %.1f %.1f', CpUtil.getName(vehicle), d, myDistanceToCollision, myEte, otherEte)
                     if math.abs(myEte - otherEte) < self.eteDiffThreshold then
                         if not self.warning:get() or (self.warning:get() and vehicle ~= self.warningVehicle) then

--- a/scripts/ai/turns/TurnManeuver.lua
+++ b/scripts/ai/turns/TurnManeuver.lua
@@ -284,13 +284,15 @@ function TurnManeuver:adjustCourseToFitField(course, dBack, ixBeforeEndingTurnSe
     if self.turnContext.turnEndForwardOffset > 0 and math.max(dFromTurnEnd, dFromWorkStart) > -self.steeringLength then
         self:debug('Reverse to work start (implement in back)')
         -- vehicle in front of the work start node at turn end
-        local forwardAfterTurn = Course.createFromNode(self.vehicle, self.turnContext.vehicleAtTurnEndNode, 0,
-                dFromTurnEnd + 1 + self.steeringLength / 2, dFromTurnEnd + 1 + self.steeringLength, 0.8, false)
-        courseWithReversing:append(forwardAfterTurn)
-        self:applyTightTurnOffset(forwardAfterTurn:getLength())
-        -- allow early direction change when aligned
-        TurnManeuver.setTurnControlForLastWaypoints(courseWithReversing, forwardAfterTurn:getLength(),
-                TurnManeuver.CHANGE_DIRECTION_WHEN_ALIGNED, true, true)
+        if self.steeringLength > 0 then
+            local forwardAfterTurn = Course.createFromNode(self.vehicle, self.turnContext.vehicleAtTurnEndNode, 0,
+                    dFromTurnEnd + 1 + self.steeringLength / 2, dFromTurnEnd + 1 + self.steeringLength, 0.8, false)
+            courseWithReversing:append(forwardAfterTurn)
+            self:applyTightTurnOffset(forwardAfterTurn:getLength())
+            -- allow early direction change when aligned
+            TurnManeuver.setTurnControlForLastWaypoints(courseWithReversing, forwardAfterTurn:getLength(),
+                    TurnManeuver.CHANGE_DIRECTION_WHEN_ALIGNED, true, true)
+        end
         -- go all the way to the back marker distance so there's plenty of room for lower early too, also, the
         -- reversingOffset may be even behind the back marker, especially for vehicles which have a AIToolReverserDirectionNode
         -- which is then used as the PPC controlled node, and thus it must be far enough that we reach the lowering


### PR DESCRIPTION
The division by zero errors should now be fixed.
 
Was not able to reproduce the problem with the savegame attached to the issue. 

There is definitely a problem with the DeWulf PK3 Profi pipe being too low after a turn and the unloader using the pathfinder has a collision with the pipe.