### PR TITLE
fix: collision flags changed

### DIFF
--- a/scripts/CpUtil.lua
+++ b/scripts/CpUtil.lua
@@ -484,5 +484,6 @@ end
 
 function CpUtil.getDefaultCollisionFlags()
 	return CollisionFlag.DEFAULT + CollisionFlag.TREE + CollisionFlag.DYNAMIC_OBJECT + 
-		CollisionFlag.VEHICLE + CollisionFlag.BUILDING + CollisionFlag.PLACEMENT_BLOCKING
+		CollisionFlag.VEHICLE + CollisionFlag.BUILDING + CollisionFlag.STATIC_OBJECT +
+		CollisionFlag.WATER
 end

--- a/scripts/ai/strategies/AIDriveStrategyCombineCourse.lua
+++ b/scripts/ai/strategies/AIDriveStrategyCombineCourse.lua
@@ -255,7 +255,7 @@ function AIDriveStrategyCombineCourse:getDriveData(dt, vX, vY, vZ)
             -- player does not want us to move while discharging
             self:setMaxSpeed(0)
         else
-            -- Slowdown the combine near the last few percent, so no crops are leftover, 
+            -- Slowdown the combine near the last few percent, so no crops are leftover,
             -- as the combine needs to stop in time, before it's full.
             local leftoverPercentage = self.fillLevelFullPercentage - self.combineController:getFillLevelPercentage()
             if (leftoverPercentage > 0 and leftoverPercentage < self.startingSlowdownFillLevelThreshold) then
@@ -2113,7 +2113,7 @@ end
 
 -- Proximity controller checking if an object/vehicle should be ignored
 function AIDriveStrategyCombineCourse:ignoreProximityObject(object, vehicle, moveForwards, hitTerrain)
-    return vehicle == self.unloaderRequestedToIgnoreProximity:get()
+    return vehicle ~= nil and vehicle == self.unloaderRequestedToIgnoreProximity:get()
 end
 
 --- Check if the unloader is blocking us when we are reversing in a turn and immediately notify it

--- a/scripts/dev/DevHelper.lua
+++ b/scripts/dev/DevHelper.lua
@@ -25,6 +25,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 --- Also showing field/fruit/collision information when walking around
 DevHelper = CpObject()
 
+DevHelper.overlapBoxWidth = 3
+DevHelper.overlapBoxHeight = 3
+DevHelper.overlapBoxLength = 5
+
 function DevHelper:init()
     self.data = {}
     self.isEnabled = false
@@ -85,7 +89,9 @@ function DevHelper:update()
 
     local collisionMask = CpUtil.getDefaultCollisionFlags() + CollisionFlag.TERRAIN_DELTA
     self.data.collidingShapes = ''
-    overlapBox(self.data.x, self.data.y + 0.2, self.data.z, 0, self.yRot, 0, 1.6, 1, 8, "overlapBoxCallback", self, collisionMask, true, true, true)
+    overlapBox(self.data.x, self.data.y + 0.2, self.data.z, 0, self.yRot, 0,
+            DevHelper.overlapBoxWidth / 2, DevHelper.overlapBoxHeight / 2, DevHelper.overlapBoxLength / 2,
+            "overlapBoxCallback", self, collisionMask, true, true, true)
 
 end
 
@@ -94,7 +100,7 @@ function DevHelper:overlapBoxCallback(transformId)
     local text
     if collidingObject then
         if collidingObject.getRootVehicle then
-            text = 'vehicle' .. collidingObject:getName()
+            text = 'vehicle ' .. collidingObject:getName()
         else
 			if collidingObject:isa(Bale) then
 				text = 'Bale ' .. tostring(collidingObject.id) .. ' ' .. tostring(collidingObject.nodeId)
@@ -206,8 +212,9 @@ function DevHelper:draw()
 	--local x, y, z = localToWorld(self.node, 0, -1, -3)
 
 	--drawDebugLine(x, y, z, 1, 1, 1, x + nx, y + ny, z + nz, 1, 1, 1)
-	--local xRot, yRot, zRot = getWorldRotation(self.tNode)
-	--DebugUtil.drawOverlapBox(self.data.x, self.data.y, self.data.z, xRot, yRot, zRot, 4, 1, 4, 0, 100, 0)
+	DebugUtil.drawOverlapBox(self.data.x, self.data.y, self.data.z, 0, self.yRot, 0,
+            DevHelper.overlapBoxWidth / 2, DevHelper.overlapBoxHeight / 2, DevHelper.overlapBoxLength / 2,
+            0, 100, 0)
     PathfinderUtil.showOverlapBoxes()
     g_fieldScanner:draw()
 end

--- a/scripts/pathfinder/PathfinderUtil.lua
+++ b/scripts/pathfinder/PathfinderUtil.lua
@@ -263,7 +263,7 @@ function PathfinderUtil.CollisionDetector.removeNodeToIgnore(node)
 end
 
 function PathfinderUtil.CollisionDetector:overlapBoxCallback(transformId)
-    if PathfinderUtil.CollisionDetector.NODES_TO_IGNORE[transformId] then 
+    if PathfinderUtil.CollisionDetector.NODES_TO_IGNORE[transformId] then
         --- Global node, that needs to be ignored
         return
     end
@@ -273,8 +273,8 @@ function PathfinderUtil.CollisionDetector:overlapBoxCallback(transformId)
         -- an object we want to ignore
         return
     end
+    local rootVehicle
     if collidingObject then
-        local rootVehicle
         if collidingObject.getRootVehicle then
             rootVehicle = collidingObject:getRootVehicle()
         elseif collidingObject:isa(Bale) and collidingObject.mountObject then
@@ -663,7 +663,7 @@ end
 function PathfinderUtil.getWaypointAsState3D(waypoint, xOffset, zOffset)
     local result = State3D(waypoint.x, -waypoint.z, CpMathUtil.angleFromGameDeg(waypoint.angle))
     if waypoint:getIsReverse() then
-        --- If it's a reverse driven waypoint, then the target heading needs to be inverted. 
+        --- If it's a reverse driven waypoint, then the target heading needs to be inverted.
         result:reverseHeading()
     end
     local offset = Vector(zOffset, -xOffset)


### PR DESCRIPTION
Removed PLACEMENT_BLOCKING which was added to avoid the rice field pumps, but was causing conflicts near other placeables and at random places, even on the middle of some fields, for whatever reason. Added STATIC_OBJECT instead, and also WATER, hoping that rice fields won't
trigger it.