### PR TITLE
Fix for #159

### DIFF
--- a/scripts/ai/tasks/CpAITaskFieldWork.lua
+++ b/scripts/ai/tasks/CpAITaskFieldWork.lua
@@ -61,10 +61,18 @@ end
 
 --- Makes sure the cp fieldworker gets started.
 function CpAITaskFieldWork:start()
+	self:debug("Field work task started.")
+	local spec = self.vehicle.spec_aiFieldWorker
+	spec.isActive = true
+	self.vehicle:raiseAIEvent("onAIFieldWorkerStart", "onAIImplementStart")
 	if self.isServer then
-		self:debug("Field work task started.")
-		self.vehicle:startFieldWorker()
-		local spec = self.vehicle.spec_aiFieldWorker
+		spec.isActive = true
+		spec:updateAIFieldWorkerImplementData()
+		if self.vehicle:getAINeedsTrafficCollisionBox() and (AIFieldWorker.TRAFFIC_COLLISION ~= nil and 
+			(AIFieldWorker.TRAFFIC_COLLISION ~= 0 and spec.aiTrafficCollision == nil)) then
+
+			spec.aiTrafficCollision = clone(AIFieldWorker.TRAFFIC_COLLISION, true, false, true)
+		end
 		local cpSpec = self.vehicle.spec_cpAIFieldWorker
 		--- Remembers the last lane offset setting value that was used.
         cpSpec.cpJobStartAtLastWp:getCpJobParameters().laneOffset:setValue(self.job:getCpJobParameters().laneOffset:getValue())

--- a/scripts/ai/tasks/CpAITaskFieldWork.lua
+++ b/scripts/ai/tasks/CpAITaskFieldWork.lua
@@ -77,6 +77,7 @@ function CpAITaskFieldWork:start()
 		--- Remembers the last lane offset setting value that was used.
         cpSpec.cpJobStartAtLastWp:getCpJobParameters().laneOffset:setValue(self.job:getCpJobParameters().laneOffset:getValue())
 		if spec.driveStrategies ~= nil then
+			-- This deltition code could be removed, but just to be sure we let it stay here for now.
 			for i = #spec.driveStrategies, 1, -1 do
 				spec.driveStrategies[i]:delete()
 				table.remove(spec.driveStrategies, i)


### PR DESCRIPTION
Avoids createting giants field strategies and deleting them directly after starting cp.

- Test:
  - Test starting/stopping of a few different fieldwork combis