### PR TITLE
fix: Don't drive with pipe in not allowed states

### DIFF
--- a/scripts/ai/controllers/PipeController.lua
+++ b/scripts/ai/controllers/PipeController.lua
@@ -62,6 +62,10 @@ function PipeController:getDriveData()
             self:debugSparse("Waiting for pipe unfolding!")
         end
     end
+    if not self:isInAllowedState() then
+        maxSpeed = 0
+        self:debugSparse("Pipe state prevents driving")
+    end
     return nil, nil, nil, maxSpeed
 end
 
@@ -669,6 +673,25 @@ function PipeController:movePipeUp(tool, childToolNode, dt)
         end
     end
     ImplementUtil.moveMovingToolToRotation(self.implement, tool, dt, CpMathUtil.clamp(targetRot, tool.rotMin, tool.rotMax))
+end
+
+---@return boolean true if the pipe is in a state which allows turning on the harvester. This is to prevent some
+--- harvesters like the OXBO MKB-4TR driving with the bunker up right after unloading, as with the bunker up they
+--- are not able to harvest
+function PipeController:isInAllowedState()
+    if self.pipeSpec.hasMovablePipe then
+        if next(self.pipeSpec.turnOnAllowedStates) ~= nil then
+            local isAllowed = false
+            for pipeState,_ in pairs(self.pipeSpec.turnOnAllowedStates) do
+                if pipeState == self.pipeSpec.currentState then
+                    isAllowed = true
+                    break
+                end
+            end
+            return isAllowed
+        end
+    end
+    return true
 end
 
 function PipeController:delete()

--- a/scripts/ai/strategies/AIDriveStrategyCombineCourse.lua
+++ b/scripts/ai/strategies/AIDriveStrategyCombineCourse.lua
@@ -741,27 +741,21 @@ function AIDriveStrategyCombineCourse:getFruitAtSides()
     return self.fruitLeft, self.fruitRight
 end
 
+--- Check both sides of the combine/chopper to see if we are at the edge of the field and if there is fruit there.
+--- This is to direct the unloader to the side where there is no fruit.
 function AIDriveStrategyCombineCourse:checkFruit()
-    -- getValidityOfTurnDirections() wants to have the vehicle.aiDriveDirection, so get that here.
-    local dx, _, dz = localDirectionToWorld(self.vehicle:getAIDirectionNode(), 0, 0, 1)
-    local length = MathUtil.vector2Length(dx, dz)
-    dx = dx / length
-    dz = dz / length
-    self.vehicle.aiDriveDirection = { dx, dz }
-    -- getValidityOfTurnDirections works only if all AI Implements have aiMarkers. Since
-    -- we make all Cutters AI implements, even the ones which do not have AI markers (such as the
-    -- chopper pickups which do not work with the Giants helper) we have to make sure we don't call
-    -- getValidityOfTurnDirections for those
-    if self.notAllImplementsHaveAiMarkers then
-        self.fruitLeft, self.fruitRight = 0, 0
-    else
-        self.fruitLeft, self.fruitRight = AIVehicleUtil.getValidityOfTurnDirections(self.vehicle)
-    end
     local workWidth = self:getWorkWidth()
+
     local x, _, z = localToWorld(self.vehicle:getAIDirectionNode(), workWidth, 0, 0)
     self.fieldOnLeft = CpFieldUtil.isOnField(x, z)
+    _, self.fruitLeft = PathfinderUtil.hasFruit(x, z, 1, 1)
+    self.fruitLeft = self.fruitLeft or 0
+
     x, _, z = localToWorld(self.vehicle:getAIDirectionNode(), -workWidth, 0, 0)
     self.fieldOnRight = CpFieldUtil.isOnField(x, z)
+    _, self.fruitRight = PathfinderUtil.hasFruit(x, z, 1, 1)
+    self.fruitRight = self.fruitRight or 0
+
     self:debug('Fruit left: %.2f right %.2f, field on left %s, right %s',
             self.fruitLeft, self.fruitRight, tostring(self.fieldOnLeft), tostring(self.fieldOnRight))
 end


### PR DESCRIPTION
This is to prevent some harvesters driving off once discharging finished with the bunker up, as that will result in leaving the area unharvested.

Also fix fruit detection for choppers so unloaders are directed to the correct side.

#176