### PR TITLE
Update translation_it.xml

### DIFF
--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -215,7 +215,7 @@
     <text name="CP_vehicle_setting_debugActive_tooltip" text="Abilita/disabilita il debug per questo veicolo"/>
     <text name="CP_vehicle_setting_refillOnTheField_title" text="Strumento di riempimento"/>
     <text name="CP_vehicle_setting_refillOnTheField_tooltip" text="Strumento di rifornimento sul campo"/>
-    <text name="CP_vehicle_setting_refillOnTheField_waiting" text="Inattesa"/>
+    <text name="CP_vehicle_setting_refillOnTheField_waiting" text="In attesa"/>
     <text name="CP_vehicle_setting_refillOnTheField_active" text="Attivo"/>
     <!---->
     <!--Vehicle bunker silo settings-->
@@ -534,7 +534,9 @@ Il percorso viene salvato automaticamente alla chiusura dell'editor e sovrascriv
 Courseplay consente di generare percorsi di campo con funzionalità aggiuntive, ad esempio: capezzagne.
 Consente inoltre l'utilizzo di presse e carri foraggio, che possono essere inviati sullo stesso percorso, come una falciatrice o una mietitrice di prima.
 Un'altra grande funzionalità è la raccolta o l'avvolgimento di balle sul campo.
+
 Courseplay è anche in grado di lavorare su risaie e viti.
+Per le risaie, è consigliato impostare il margine campo, nelle impostazioni del campo, a 0.8/1, per evitare la fermata dell'aiutante, in prossimità delle svolte ad angolo retto, ed anche la piantumazione fuori dalla parte allagata, in particolare per i campi non squdarati.
 I percorsi di lavoro sul campo possono essere impostati in modalità multiutensile, che consente l'utilizzo di un massimo di 5 conducenti che lavorano in un convoglio sullo stesso campo.
 È anche possibile far scaricare la mietitrebbia in un rimorchio sul/vicino al campo automaticamente.
 È possibile assegnare confini di campo personalizzati per l'utilizzo di Courseplay, ad esempio: nel caso di un prato, che non è riconosciuto come un campo normale.
@@ -1047,9 +1049,9 @@ Ora la tua selezione dovrebbe essere simile all'immagine.
     <text name="input_CP_DBG_CHANNEL_MENU_VISIBILITY" text="CP: Mostra il menù del canale di debug si/no"/>
     <text name="input_CP_OPEN_CLOSE_VEHICLE_SETTING_DISPLAY" text="CP: Apri mini GUI"/>
     <text name="input_CP_START_STOP" text="CP: Avvia/Ferma autista"/>
-    <text name="input_CP_START_STOP_AT_FIRST_WAYPOINT" text="CP: Start/stop driver (at first waypoint)"/>
-    <text name="input_CP_START_STOP_AT_NEAREST_WAYPOINT" text="CP: Start/stop driver (at nearest waypoint)"/>
-    <text name="input_CP_START_STOP_AT_LAST_WAYPOINT" text="CP: Start/stop driver (at last waypoint)"/>
+    <text name="input_CP_START_STOP_AT_FIRST_WAYPOINT" text="CP: Avvia/arresta il conducente (al primo waypoint)"/>
+    <text name="input_CP_START_STOP_AT_NEAREST_WAYPOINT" text="CP: Avvia/arresta il conducente (al waypoint più vicino)"/>
+    <text name="input_CP_START_STOP_AT_LAST_WAYPOINT" text="CP: Avvia/arresta il conducente (all'ultimo waypoint)"/>
     <text name="input_CP_GENERATE_COURSE" text="CP: Cambia il lavoro attualmente selezionato"/>
     <text name="input_CP_CHANGE_SELECTED_JOB" text="CP: Cambia lavoro selezionato"/>
     <text name="input_CP_CHANGE_STARTING_POINT" text="CP: Cambia punto di partenza"/>
@@ -1061,6 +1063,6 @@ Ora la tua selezione dovrebbe essere simile all'immagine.
     <text name="input_CP_OPEN_GLOBAL_SETTINGS" text="CP: Apre le impostazioni globali"/>
     <text name="input_CP_OPEN_COURSEGENERATOR_SETTINGS" text="CP: Apri il generatore di corsi/menu dei lavori"/>
     <text name="input_CP_OPEN_COURSEMANAGER" text="CP: Apre gestore percorsi"/>
-    <text name="input_CP_OPEN_INGAME_MENU" text="CP: Apri menu"/>
+	<text name="input_CP_OPEN_INGAME_MENU" text="CP: Apri menu"/>
   </texts>
 </l10n>


### PR DESCRIPTION
Also added this line as a tip for rice planting:

For rice fields, it is recommended to set the field margin, in the field settings, to 0.8/1, to avoid the helper stopping, near right-angled turns, and also planting outside the flooded part, especially for unsquared fields.