### PR TITLE
fix: disable special rice field scanning

### DIFF
--- a/scripts/dev/DevHelper.lua
+++ b/scripts/dev/DevHelper.lua
@@ -164,6 +164,8 @@ function DevHelper:keyEvent(unicode, sym, modifier, isDown)
     elseif bitAND(modifier, Input.MOD_LCTRL) ~= 0 and isDown and sym == Input.KEY_space then
         -- restore vehicle position
         DevHelper.restoreVehiclePosition(CpUtil.getCurrentVehicle())
+    elseif bitAND(modifier, Input.MOD_LALT) ~= 0 and isDown and sym == Input.KEY_c then
+        CpFieldUtil.detectFieldBoundary(self.data.x, self.data.z, true)
     elseif bitAND(modifier, Input.MOD_LALT) ~= 0 and isDown and sym == Input.KEY_g then
         local points = CpFieldUtil.detectFieldBoundary(self.data.x, self.data.z, true)
         self:debug('Generate course')

--- a/scripts/field/CpFieldUtil.lua
+++ b/scripts/field/CpFieldUtil.lua
@@ -196,7 +196,7 @@ function CpFieldUtil.detectFieldBoundary(x, z, detect, useGiantsDetector)
         else
             local y = getTerrainHeightAtWorldPos(g_terrainNode, x, 0, z)
             local _, _, _, riceField = PlaceableRiceField.getRiceFieldAtPosition(x, y, z)
-            if riceField then
+            if false and riceField then
                 -- rice fields are somewhat special, so always use the Giants method
                 CpUtil.info('Rice field found')
                 return CpFieldUtil.getRiceFieldPolygon(riceField)


### PR DESCRIPTION
No idea why we even introduced the special rice field scanning, rice fields now seem to work just as any other field.

Add Left-Alt-C shortcut to devhelper to scan field.