### PR TITLE
fix: unloader field polygon

### DIFF
--- a/scripts/ai/strategies/AIDriveStrategyUnloadCombine.lua
+++ b/scripts/ai/strategies/AIDriveStrategyUnloadCombine.lua
@@ -1555,8 +1555,14 @@ end
 ---@param outwardsOffset number
 ---@return boolean
 function AIDriveStrategyUnloadCombine:isServingPosition(x, z, outwardsOffset)
-    local closestDistance = CpMathUtil.getClosestDistanceToPolygonEdge(self.vehicle:cpGetFieldPolygon(), x, z)
-    return closestDistance < outwardsOffset or CpMathUtil.isPointInPolygon(self.vehicle:cpGetFieldPolygon(), x, z)
+    if self.vehicle:cpGetFieldPolygon() then
+        local closestDistance = CpMathUtil.getClosestDistanceToPolygonEdge(self.vehicle:cpGetFieldPolygon(), x, z)
+        return closestDistance < outwardsOffset or CpMathUtil.isPointInPolygon(self.vehicle:cpGetFieldPolygon(), x, z)
+    else
+        -- no field polygon yet. This may be called by the combine who has no idea where are we in the field boundary
+        -- detection process.
+        return false
+    end
 end
 
 --- Am I ready to be assigned to a combine in need?

--- a/scripts/util/CpMathUtil.lua
+++ b/scripts/util/CpMathUtil.lua
@@ -129,8 +129,10 @@ end
 -- with long edges
 function CpMathUtil.getClosestDistanceToPolygonEdge(polygon, x, z)
     local closestDistance = math.huge
-    for _, p in ipairs(polygon) do
-        local d = MathUtil.getPointPointDistance(x, z, p.x, p.z)
+    for i = 1, #polygon do
+		local s, e = polygon[i], polygon[i + 1] or polygon[1]
+		local edge = CourseGenerator.LineSegment(s.x, -s.z, e.x, -e.z)
+        local d = edge:getDistanceFrom(Vector(x, -z))
         closestDistance = d < closestDistance and d or closestDistance
     end
     return closestDistance


### PR DESCRIPTION
#475 - when the combine asks for an unloader, the
unloader may not yet have the field polygon.

No idea if this was the problem only, or there is a multiplayer specific problem here too.

#456 - point to polygon distance fixed, so combine self unload, unloader start, baler start should not erroneously detect being too far from field.