### PR TITLE
fix: island boundary vertices

### DIFF
--- a/scripts/courseGenerator/Island.lua
+++ b/scripts/courseGenerator/Island.lua
@@ -23,6 +23,8 @@ end
 function Island.createFromBoundary(id, boundary)
     local island = CourseGenerator.Island(id, {})
     island.boundary = boundary
+    -- Giants polygons are usually just the corner vertices, our generator likes many vertices...
+    island.boundary:splitEdges(CourseGenerator.cMaxEdgeLength)
     return island
 end
 


### PR DESCRIPTION
Make sure island boundaries have vertices every few meters, even if the polygon has long straight edges.

Would also be possible to add waypoints to the generated course, as this really is a driving problem, not a generation problem, but the grassfire algorithm generating the headlands works better with more vertices.