### PR TITLE
Fix LUA method 'update' error in Courseplay

### DIFF
--- a/scripts/ai/jobs/CpAIJobCombineUnloader.lua
+++ b/scripts/ai/jobs/CpAIJobCombineUnloader.lua
@@ -68,21 +68,26 @@ function CpAIJobCombineUnloader:applyCurrentState(vehicle, mission, farmId, isDi
 
 	self:copyFrom(vehicle:getCpCombineUnloaderJob())
 
-	local x, z = self.cpJobParameters.fieldPosition:getPosition()
-	-- no field position from the previous job, use the vehicle's current position
-	if x == nil or z == nil then
-		x, _, z = getWorldTranslation(vehicle.rootNode)
-		self.cpJobParameters.fieldPosition:setPosition(x, z)
+	if self.cpJobParameters.fieldPosition then
+		local x, z = self.cpJobParameters.fieldPosition:getPosition()
+		-- no field position from the previous job, use the vehicle's current position
+		if x == nil or z == nil then
+			x, _, z = getWorldTranslation(vehicle.rootNode)
+			self.cpJobParameters.fieldPosition:setPosition(x, z)
+		end
 	end
-	x, z = self.cpJobParameters.fieldUnloadPosition:getPosition()
-	local angle = self.cpJobParameters.fieldUnloadPosition:getAngle()
-	-- no field position from the previous job, use the vehicle's current position
-	if x == nil or z == nil or angle == nil then
-		x, _, z = getWorldTranslation(vehicle.rootNode)
-		local dirX, _, dirZ = localDirectionToWorld(vehicle.rootNode, 0, 0, 1)
-		angle = MathUtil.getYRotationFromDirection(dirX, dirZ)
-		self.cpJobParameters.fieldUnloadPosition:setPosition(x, z)
-		self.cpJobParameters.fieldUnloadPosition:setAngle(angle)
+
+	if self.cpJobParameters.fieldUnloadPosition then
+		local x, z = self.cpJobParameters.fieldUnloadPosition:getPosition()
+		local angle = self.cpJobParameters.fieldUnloadPosition:getAngle()
+		-- no field position from the previous job, use the vehicle's current position
+		if x == nil or z == nil or angle == nil then
+			x, _, z = getWorldTranslation(vehicle.rootNode)
+			local dirX, _, dirZ = localDirectionToWorld(vehicle.rootNode, 0, 0, 1)
+			angle = MathUtil.getYRotationFromDirection(dirX, dirZ)
+			self.cpJobParameters.fieldUnloadPosition:setPosition(x, z)
+			self.cpJobParameters.fieldUnloadPosition:setAngle(angle)
+		end
 	end
 end
 

--- a/scripts/courseGenerator/FieldworkCourseTwoSided.lua
+++ b/scripts/courseGenerator/FieldworkCourseTwoSided.lua
@@ -26,6 +26,11 @@ function FieldworkCourseTwoSided:init(context)
     self.logger = Logger('FieldworkCourseTwoSided')
     context:setRowPattern(CourseGenerator.RowPatternAlternatingFirstRowEntryOnly())
     self:_setContext(context)
+    -- Add nil check for self.boundary
+    if not self.boundary then
+        self.context:addError(self.logger, 'Boundary is nil')
+        return
+    end
     -- clockwise setting really does not matter but the generated headland is expected match the boundary
     self.virtualHeadland = CourseGenerator.FieldworkCourseHelper.createVirtualHeadland(self.boundary, self.boundary:isClockwise(),
             self.context.workingWidth)
@@ -81,6 +86,11 @@ function FieldworkCourseTwoSided:getCenterPath()
 end
 
 function FieldworkCourseTwoSided:generateHeadlands()
+    -- Add nil check for self.startHeadlandBlock
+    if not self.startHeadlandBlock then
+        self.context:addError(self.logger, 'Start headland block is nil')
+        return
+    end
     -- this is the side where we start working, generate here headlands parallel to the field edge
     -- block 1 on the drawing above
     self:_createStartHeadlandBlock()

--- a/scripts/specializations/CpAIFieldWorker.lua
+++ b/scripts/specializations/CpAIFieldWorker.lua
@@ -78,6 +78,10 @@ function CpAIFieldWorker:onLoad(savegame)
 	--- Register the spec: spec_cpAIFieldWorker
     self.spec_cpAIFieldWorker = self["spec_" .. CpAIFieldWorker.SPEC_NAME]
     local spec = self.spec_cpAIFieldWorker
+    if spec == nil then
+        CpUtil.error("spec_cpAIFieldWorker is nil in onLoad")
+        return
+    end
     --- This job is for starting the driving with a key bind or the hud.
     spec.cpJob = g_currentMission.aiJobTypeManager:createJob(AIJobType.FIELDWORK_CP)
     spec.cpJob:getCpJobParameters().startAt:setValue(CpFieldWorkJobParameters.START_AT_NEAREST_POINT)
@@ -91,6 +95,10 @@ end
 
 function CpAIFieldWorker:onLoadFinished(savegame)
     local spec = self.spec_cpAIFieldWorker
+    if spec == nil then
+        CpUtil.error("spec_cpAIFieldWorker is nil in onLoadFinished")
+        return
+    end
     if savegame ~= nil then 
         spec.cpJob:getCpJobParameters():loadFromXMLFile(savegame.xmlFile, savegame.key.. CpAIFieldWorker.KEY..".cpJob")
         spec.cpJobStartAtLastWp:getCpJobParameters():loadFromXMLFile(savegame.xmlFile, savegame.key.. CpAIFieldWorker.KEY..".cpJobStartAtLastWp")
@@ -235,7 +243,7 @@ end
 
 function CpAIFieldWorker:onCpADRestarted()
     local spec = self.spec_cpAIFieldWorker
- 
+  
 end
 
 --- Event listener called, when an implement is full.

--- a/scripts/util/CpMathUtil.lua
+++ b/scripts/util/CpMathUtil.lua
@@ -72,15 +72,14 @@ end
 --	-1	point is outside of polygon
 --	 0	point is directly on polygon
 function CpMathUtil.isPointInPolygon(polygon, x, z)
+	if polygon == nil or #polygon <= 2 then 
+		CpUtil.error("CpMathUtil.isPointInPolygon(): polygon is too small or nil!")
+		return false
+	end
 	if x == nil or z == nil then 
 		CpUtil.error("CpMathUtil.isPointInPolygon(): x or z are nil!")
 		return false
 	end
-	if polygon == nil or #polygon <= 2 then 
-		CpUtil.error("CpMathUtil.isPointInPolygon(): polygon is to small or nil!")
-		return false
-	end
-
 
 	local function crossProductQuery(a, b, c)
 		-- returns:
@@ -136,6 +135,10 @@ end
 ---@return boolean true if the point is within the distance to any of the edges
 ---@return number the distance to the closest edge
 function CpMathUtil.isWithinDistanceToPolygon(polygon, x, z, distance)
+	if polygon == nil or #polygon <= 2 then 
+		CpUtil.error("CpMathUtil.isWithinDistanceToPolygon(): polygon is too small or nil!")
+		return false, math.huge
+	end
 	local closestDistance = math.huge
 	local point = Vector(x, -z)
 	for i = 1, #polygon do


### PR DESCRIPTION
Fixes #559

Fix LUA method 'update' crash when generating a course on Field 90. This fixes the issue for me at least.

* Add nil check for `self.boundary` in `FieldworkCourseTwoSided:init` function in `scripts/courseGenerator/FieldworkCourseTwoSided.lua`.
* Add nil check for `self.startHeadlandBlock` in `FieldworkCourseTwoSided:generateHeadlands` function in `scripts/courseGenerator/FieldworkCourseTwoSided.lua`.
* Add nil check for `polygon` in `CpMathUtil.isPointInPolygon` function in `scripts/util/CpMathUtil.lua`.
* Add nil check for `polygon` in `CpMathUtil.isWithinDistanceToPolygon` function in `scripts/util/CpMathUtil.lua`.
* Add nil check for `self.cpJobParameters.fieldPosition` in `CpAIJobCombineUnloader:applyCurrentState` function in `scripts/ai/jobs/CpAIJobCombineUnloader.lua`.
* Add nil check for `self.cpJobParameters.fieldUnloadPosition` in `CpAIJobCombineUnloader:applyCurrentState` function in `scripts/ai/jobs/CpAIJobCombineUnloader.lua`.
* Add nil check for `self.spec_cpAIFieldWorker` in `CpAIFieldWorker:onLoad` function in `scripts/specializations/CpAIFieldWorker.lua`.
* Add nil check for `self.spec_cpAIFieldWorker` in `CpAIFieldWorker:onLoadFinished` function in `scripts/specializations/CpAIFieldWorker.lua`.

