### PR TITLE
fix: possible specialization race condition

### DIFF
--- a/scripts/specializations/CpAIFieldWorker.lua
+++ b/scripts/specializations/CpAIFieldWorker.lua
@@ -9,6 +9,11 @@ CpAIFieldWorker.NAME = ".cpAIFieldWorker"
 CpAIFieldWorker.SPEC_NAME = CpAIFieldWorker.MOD_NAME .. CpAIFieldWorker.NAME
 CpAIFieldWorker.KEY = "."..CpAIFieldWorker.MOD_NAME..CpAIFieldWorker.NAME
 
+-- shortcut to access the spec
+function CpAIFieldWorker.getSpec(self)
+    return self["spec_" .. CpAIFieldWorker.SPEC_NAME]
+end
+
 function CpAIFieldWorker.initSpecialization()
     local schema = Vehicle.xmlSchemaSavegame
     local key = "vehicles.vehicle(?)" .. CpAIFieldWorker.KEY
@@ -76,8 +81,8 @@ end
 ---------------------------------------------------------------------------------------------------------------------------
 function CpAIFieldWorker:onLoad(savegame)
 	--- Register the spec: spec_cpAIFieldWorker
-    self.spec_cpAIFieldWorker = self["spec_" .. CpAIFieldWorker.SPEC_NAME]
-    local spec = self.spec_cpAIFieldWorker
+    self.spec_cpAIFieldWorker = CpAIFieldWorker.getSpec(self)
+    local spec = CpAIFieldWorker.getSpec(self)
     --- This job is for starting the driving with a key bind or the hud.
     spec.cpJob = g_currentMission.aiJobTypeManager:createJob(AIJobType.FIELDWORK_CP)
     spec.cpJob:getCpJobParameters().startAt:setValue(CpFieldWorkJobParameters.START_AT_NEAREST_POINT)
@@ -90,7 +95,7 @@ function CpAIFieldWorker:onLoad(savegame)
 end
 
 function CpAIFieldWorker:onLoadFinished(savegame)
-    local spec = self.spec_cpAIFieldWorker
+    local spec = CpAIFieldWorker.getSpec(self)
     if savegame ~= nil then 
         spec.cpJob:getCpJobParameters():loadFromXMLFile(savegame.xmlFile, savegame.key.. CpAIFieldWorker.KEY..".cpJob")
         spec.cpJobStartAtLastWp:getCpJobParameters():loadFromXMLFile(savegame.xmlFile, savegame.key.. CpAIFieldWorker.KEY..".cpJobStartAtLastWp")
@@ -98,13 +103,13 @@ function CpAIFieldWorker:onLoadFinished(savegame)
 end
 
 function CpAIFieldWorker:saveToXMLFile(xmlFile, baseKey, usedModNames)
-    local spec = self.spec_cpAIFieldWorker
+    local spec = CpAIFieldWorker.getSpec(self)
     spec.cpJob:getCpJobParameters():saveToXMLFile(xmlFile, baseKey.. ".cpJob")
     spec.cpJobStartAtLastWp:getCpJobParameters():saveToXMLFile(xmlFile, baseKey.. ".cpJobStartAtLastWp")
 end
 
 function CpAIFieldWorker:onStateChange(state, data)
-    local spec = self.spec_cpAIFieldWorker
+    local spec = CpAIFieldWorker.getSpec(self)
     if state == VehicleStateChange.ATTACH then
         spec.cpJob:getCpJobParameters():validateSettings()
     elseif state == VehicleStateChange.DETACH then
@@ -113,19 +118,19 @@ function CpAIFieldWorker:onStateChange(state, data)
 end
 
 function CpAIFieldWorker:onCpCourseChange()
-    local spec = self.spec_cpAIFieldWorker
+    local spec = CpAIFieldWorker.getSpec(self)
     if spec.cpJob then
         spec.cpJob:getCpJobParameters():validateSettings()
     end
 end
 
 function CpAIFieldWorker:getCpStartingPointSetting()
-    local spec = self.spec_cpAIFieldWorker
+    local spec = CpAIFieldWorker.getSpec(self)
     return spec.cpJob:getCpJobParameters().startAt
 end
 
 function CpAIFieldWorker:getCpLaneOffsetSetting()
-    local spec = self.spec_cpAIFieldWorker
+    local spec = CpAIFieldWorker.getSpec(self)
     return spec.cpJob:getCpJobParameters().laneOffset
 end
 
@@ -147,7 +152,7 @@ end
 
 --- Gets the current field work drive strategy.
 function CpAIFieldWorker:getCpDriveStrategy(superFunc)
-    return superFunc(self) or self.spec_cpAIFieldWorker.driveStrategy
+    return superFunc(self) or (self.spec_cpAIFieldWorker and self.spec_cpAIFieldWorker.driveStrategy)
 end
 
 --- To find out if a harvester is waiting to be unloaded, either because it is full or ended the fieldwork course
@@ -195,7 +200,7 @@ end
 
 --- Starts the cp driver at the first waypoint.
 function CpAIFieldWorker:startCpAtFirstWp()
-    local spec = self.spec_cpAIFieldWorker
+    local spec = CpAIFieldWorker.getSpec(self)
     self:updateAIFieldWorkerImplementData()
     if self:hasCpCourse() and self:getCanStartCpFieldWork() then
         spec.cpJobStartAtFirstWp:applyCurrentState(self, g_currentMission, g_currentMission.playerSystem:getLocalPlayer().farmId, true, false)
@@ -212,7 +217,7 @@ end
 
 --- Starts the cp driver at the last driven waypoint.
 function CpAIFieldWorker:startCpAtLastWp()
-    local spec = self.spec_cpAIFieldWorker
+    local spec = CpAIFieldWorker.getSpec(self)
     self:updateAIFieldWorkerImplementData()
     if self:hasCpCourse() and self:getCanStartCpFieldWork() then
         spec.cpJobStartAtLastWp:applyCurrentState(self, g_currentMission, g_currentMission.playerSystem:getLocalPlayer().farmId, true, false)
@@ -228,13 +233,13 @@ function CpAIFieldWorker:startCpAtLastWp()
 end
 
 function CpAIFieldWorker:onCpADStartedByPlayer()
-    local spec = self.spec_cpAIFieldWorker
+    local spec = CpAIFieldWorker.getSpec(self)
     --- Applies the lane offset set in the hud, so ad can start with the correct one.
     spec.cpJobStartAtLastWp:getCpJobParameters().laneOffset:setValue(self:getCpLaneOffsetSetting():getValue())
 end
 
 function CpAIFieldWorker:onCpADRestarted()
-    local spec = self.spec_cpAIFieldWorker
+    local spec = CpAIFieldWorker.getSpec(self)
  
 end
 
@@ -296,7 +301,7 @@ end
 
 --- Gets the field work job for the hud or start action event.
 function CpAIFieldWorker:getCpStartableJob(superFunc, isStartedByHud)
-    local spec = self.spec_cpAIFieldWorker
+    local spec = CpAIFieldWorker.getSpec(self)
     if isStartedByHud and self:cpIsHudFieldWorkJobSelected() then 
         return self:getCanStartCpFieldWork() and self:hasCpCourse() and spec.cpJob
     end

--- a/scripts/specializations/CpCourseManager.lua
+++ b/scripts/specializations/CpCourseManager.lua
@@ -118,10 +118,15 @@ function CpCourseManager.registerFunctions(vehicleType)
     SpecializationUtil.registerFunction(vehicleType, 'setCpCoursesFromNetworkEvent', CpCourseManager.setCoursesFromNetworkEvent)
 end
 
+function CpCourseManager.getSpec(self)
+    return self["spec_" .. CpCourseManager.SPEC_NAME]
+end
+
 function CpCourseManager:onLoad(savegame)
 	--- Register the spec: spec_cpCourseManager 
-    self.spec_cpCourseManager = self["spec_" .. CpCourseManager.SPEC_NAME]
-    local spec = self.spec_cpCourseManager 
+    self.spec_cpCourseManager = CpCourseManager.getSpec(self)
+    local spec = CpCourseManager.getSpec(self)
+ 
     spec.coursePlot = CoursePlot(g_inGameMenu.ingameMap)
 
     spec.courses = {}
@@ -142,7 +147,7 @@ function CpCourseManager:onPostLoad(savegame)
 end
 
 function CpCourseManager:loadAssignedCourses(xmlFile, baseKey, noEventSend, name)
-    local spec = self.spec_cpCourseManager 
+    local spec = CpCourseManager.getSpec(self)
     local courses = {}
     xmlFile:iterate(baseKey,function (i,key)
         CpUtil.debugVehicle(CpDebug.DBG_COURSES,self,"Loading assigned course: %s",key)
@@ -172,7 +177,7 @@ function CpCourseManager:saveToXMLFile(xmlFile, baseKey, usedModNames)
 end
 
 function CpCourseManager:saveAssignedCourses(xmlFile, baseKey,name)
-    local spec = self.spec_cpCourseManager 
+    local spec = CpCourseManager.getSpec(self)
     local courses = spec.courses
     if courses ~=nil and next(courses) then
         for i=1,#courses do 
@@ -187,12 +192,12 @@ function CpCourseManager:saveAssignedCourses(xmlFile, baseKey,name)
 end
 
 function CpCourseManager:setCpAssignedCoursesID(id)
-    local spec = self.spec_cpCourseManager 
+    local spec = CpCourseManager.getSpec(self)
     spec.assignedCoursesID = id
 end
 
 function CpCourseManager:getCpAssignedCoursesID()
-    local spec = self.spec_cpCourseManager 
+    local spec = CpCourseManager.getSpec(self)
     return spec.assignedCoursesID
 end
 
@@ -216,14 +221,14 @@ function CpCourseManager:setCoursesFromNetworkEvent(courses)
 end
 
 function CpCourseManager:addCourse(course,noEventSend)
-    local spec = self.spec_cpCourseManager
+    local spec = CpCourseManager.getSpec(self)
     course:setVehicle(self)
     table.insert(spec.courses,course)
     SpecializationUtil.raiseEvent(self,"onCpCourseChange",course,noEventSend)
 end
 
 function CpCourseManager:resetCourses()
-    local spec = self.spec_cpCourseManager
+    local spec = CpCourseManager.getSpec(self)
     if spec and spec.courses then
         spec.courses = {}
         spec.assignedCoursesID = nil
@@ -238,23 +243,23 @@ end
 
 ---@return Course
 function CpCourseManager:getFieldWorkCourse()
-    local spec = self.spec_cpCourseManager 
+    local spec = CpCourseManager.getSpec(self)
     --- TODO: For now only returns the first course.
     return spec.courses[1]
 end
 
 function CpCourseManager:getCourses()
-    local spec = self.spec_cpCourseManager 
+    local spec = CpCourseManager.getSpec(self)
     return spec.courses
 end
 
 function CpCourseManager:hasCourse()
-    local spec = self.spec_cpCourseManager 
+    local spec = CpCourseManager.getSpec(self)
     return next(spec.courses) ~= nil
 end
 
 function CpCourseManager:updateCpCourseDisplayVisibility()
-    local spec = self.spec_cpCourseManager
+    local spec = CpCourseManager.getSpec(self)
     local visibilityMode = self:getCpSettings().showCourse:getValue()
     spec.courseDisplay:updateVisibility(visibilityMode == CpVehicleSettings.SHOW_COURSE_ALL, 
                                         visibilityMode == CpVehicleSettings.SHOW_COURSE_START_STOP, 
@@ -272,7 +277,7 @@ function CpCourseManager:onCpFieldworkWaypointChanged(wpIx)
 end
 
 function CpCourseManager:onCpShowCourseSettingChanged(showCourseSetting)
-    local spec = self.spec_cpCourseManager
+    local spec = CpCourseManager.getSpec(self)
     if spec then
         self:updateCpCourseDisplayVisibility()
     end
@@ -280,7 +285,8 @@ end
 
 function CpCourseManager:onEnterVehicle(isControlling)
     if isControlling then
-        local spec = self.spec_cpCourseManager
+        local spec = CpCourseManager.getSpec(self)
+
         if spec.courseDisplay then
             spec.courseDisplay:setVisible(true)
             self:updateCpCourseDisplayVisibility()
@@ -290,7 +296,7 @@ end
 
 function CpCourseManager:onLeaveVehicle(wasEntered)
     if wasEntered then
-        local spec = self.spec_cpCourseManager
+        local spec = CpCourseManager.getSpec(self)
         if spec.courseDisplay then
             spec.courseDisplay:setVisible(false)
         end
@@ -298,8 +304,8 @@ function CpCourseManager:onLeaveVehicle(wasEntered)
 end
 
 function CpCourseManager:onCpCourseChange(newCourse,noEventSend)
-    local spec = self.spec_cpCourseManager
-    if newCourse then 
+    local spec = CpCourseManager.getSpec(self)
+    if newCourse then
         -- we have course, show the course plot on the AI helper screen
         spec.coursePlot:setWaypoints(newCourse.waypoints)
         spec.coursePlot:setVisible(true)
@@ -307,14 +313,12 @@ function CpCourseManager:onCpCourseChange(newCourse,noEventSend)
             CoursesEvent.sendEvent(self,spec.courses)   
         end
         if g_client then
-            local spec = self.spec_cpCourseManager 
             spec.courseDisplay:setCourse(self:getFieldWorkCourse())
             self:updateCpCourseDisplayVisibility()
         end
     else 
         spec.coursePlot:setVisible(false)
         self:rememberCpLastWaypointIx()
-        local spec = self.spec_cpCourseManager 
         self:updateCpCourseDisplayVisibility()
         if spec.courseDisplay then
             spec.courseDisplay:clear()
@@ -329,7 +333,7 @@ end
 
 function CpCourseManager:drawCpCoursePlot(map, isHudMap)
     if self:hasCpCourse() then
-        local spec = self.spec_cpCourseManager
+        local spec = CpCourseManager.getSpec(self)
         spec.coursePlot:draw(map, isHudMap)
     end
 end
@@ -352,7 +356,7 @@ function CpCourseManager:onReadStream(streamId,connection)
 end
 
 function CpCourseManager:onWriteStream(streamId,connection)
-	local spec = self.spec_cpCourseManager
+	local spec = CpCourseManager.getSpec(self)
     streamWriteUInt8(streamId,#spec.courses)
     for i,course in ipairs(spec.courses) do 
         course:writeStream(self, streamId, connection)
@@ -360,11 +364,10 @@ function CpCourseManager:onWriteStream(streamId,connection)
 end
 
 function CpCourseManager:onPreDelete()
-    local spec = self.spec_cpCourseManager 
+    local spec = CpCourseManager.getSpec(self)
     if spec then
         g_assignedCoursesManager:unregisterVehicle(self, self.id)
         CpCourseManager.resetCourses(self)
-        local spec = self.spec_cpCourseManager 
         spec.courseDisplay:delete()
         spec.courseDisplay = nil
     end
@@ -417,7 +420,7 @@ function CpCourseManager:saveCourses(file,text)
 end
 
 function CpCourseManager:setCpCourseName(name)
-    local spec = self.spec_cpCourseManager
+    local spec = CpCourseManager.getSpec(self)
     local course = spec.courses[1]
     if course then 
         course:setName(name)
@@ -426,7 +429,7 @@ function CpCourseManager:setCpCourseName(name)
 end
 
 function CpCourseManager:cpReverseCurrentCourse(noEventSend)
-    local spec = self.spec_cpCourseManager
+    local spec = CpCourseManager.getSpec(self)
     ---@type Course
     local course = spec.courses[1]
     if course then
@@ -444,12 +447,12 @@ function CpCourseManager:cpReverseCurrentCourse(noEventSend)
 end
 
 function CpCourseManager:rememberCpLastWaypointIx(ix)
-    local spec = self.spec_cpCourseManager
+    local spec = CpCourseManager.getSpec(self)
     spec.rememberedWpIx = ix
 end
 
 function CpCourseManager:getCpLastRememberedWaypointIx()
-    local spec = self.spec_cpCourseManager
+    local spec = CpCourseManager.getSpec(self)
     return spec.rememberedWpIx
 end
 
@@ -457,35 +460,35 @@ end
 --- Recording
 ------------------------------------------------------------------------------------------------------------------------
 function CpCourseManager:onUpdate()
-    local spec = self.spec_cpCourseManager
+    local spec = CpCourseManager.getSpec(self)
     spec.courseRecorder:update()
 end
 
 function CpCourseManager:cpStartCourseRecorder()
-    local spec = self.spec_cpCourseManager
+    local spec = CpCourseManager.getSpec(self)
     spec.courseRecorder:start(self)
 end
 
 function CpCourseManager:cpStopCourseRecorder()
-    local spec = self.spec_cpCourseManager
+    local spec = CpCourseManager.getSpec(self)
     spec.courseRecorder:stop()
     g_customFieldManager:addField(spec.courseRecorder:getRecordedWaypoints())
 end
 
 
 function CpCourseManager:getIsCpCourseRecorderActive()
-    local spec = self.spec_cpCourseManager
+    local spec = CpCourseManager.getSpec(self)
     return spec.courseRecorder:isRecording()
 end
 
 function CpCourseManager:getIsCpCourseRecorderPaused()
-    local spec = self.spec_cpCourseManager
+    local spec = CpCourseManager.getSpec(self)
     return self:getIsCpCourseRecorderActive() and spec.courseRecorder:isPaused()
 end
 
 function CpCourseManager:toggleCpCourseRecorderPause()
-    local spec = self.spec_cpCourseManager
-    if self:getIsCpCourseRecorderActive() then 
+    local spec = CpCourseManager.getSpec(self)
+    if self:getIsCpCourseRecorderActive() then
         if self:getIsCpCourseRecorderPaused() then 
             spec.courseRecorder:unpause()
         else 

--- a/scripts/specializations/CpCourseManager.lua
+++ b/scripts/specializations/CpCourseManager.lua
@@ -18,6 +18,11 @@ CpCourseManager.i18n = {
 	["temporaryCourse"] = "CP_courseManager_temporary_course",
 }
 
+-- shortcut to access the spec
+function CpCourseManager.getSpec(self)
+    return self["spec_" .. CpCourseManager.SPEC_NAME]
+end
+
 --- generic xml course schema for saving/loading.
 function CpCourseManager.registerXmlSchemaValues(schema,baseKey)
 	baseKey = baseKey or ""
@@ -116,10 +121,6 @@ function CpCourseManager.registerFunctions(vehicleType)
     SpecializationUtil.registerFunction(vehicleType, 'setCpAssignedCoursesID', CpCourseManager.setCpAssignedCoursesID)
 
     SpecializationUtil.registerFunction(vehicleType, 'setCpCoursesFromNetworkEvent', CpCourseManager.setCoursesFromNetworkEvent)
-end
-
-function CpCourseManager.getSpec(self)
-    return self["spec_" .. CpCourseManager.SPEC_NAME]
 end
 
 function CpCourseManager:onLoad(savegame)
@@ -245,7 +246,7 @@ end
 function CpCourseManager:getFieldWorkCourse()
     local spec = CpCourseManager.getSpec(self)
     --- TODO: For now only returns the first course.
-    return spec.courses[1]
+    return spec.courses and spec.courses[1]
 end
 
 function CpCourseManager:getCourses()


### PR DESCRIPTION
We create a shortcut member (spec_cp<CP specialization name>) for the vehicle in the specialization's onLoad() function. It seems that sometimes there are other methods of the specialization are called before onLoad(), primarily when the vehicle is configured in the shop, so when these methods try to access the specialization through this shortcut, it is nil.

Introduce a function that returns the specialization, without using the shortcut and use that to access the specialization everywhere.

#655 #578 #586