### PR TITLE
WIP rewrite the job stopping logic

### DIFF
--- a/scripts/ai/controllers/BaleLoaderController.lua
+++ b/scripts/ai/controllers/BaleLoaderController.lua
@@ -125,3 +125,7 @@ end
 function BaleLoaderController:isReadyToLoadNextBale()
     return false
 end
+
+function BaleLoaderController:onPreFinished()
+    return self:canBeFolded()
+end

--- a/scripts/ai/controllers/BalerController.lua
+++ b/scripts/ai/controllers/BalerController.lua
@@ -26,6 +26,7 @@ function BalerController:init(vehicle, baler)
     self.slowDownStartSpeed = 20
     self.balerSpec = self.baler.spec_baler
     self.baleWrapperSpec = self.baler.spec_baleWrapper
+    self.baleLoaderSpec = self.baler.spec_baleLoader
     self.lastDroppedBale = CpTemporaryObject()
     self:debug('Baler controller initialized')
     local additives = self.balerSpec.additives
@@ -124,11 +125,20 @@ function BalerController:onStart()
     end
 end
 
-function BalerController:onFinished(hasFinished)
-    -- TODO: not working, as this probably needs to be called, before the drive is released.
-    -- if hasFinished and not self.balerSpec.automaticDrop or not self.balerSpec.platformAutomaticDrop then
-    --     Baler.actionEventUnloading(self.implement)
-    -- end
+function BalerController:onPreFinished(hasFinished)
+    if hasFinished then 
+        Baler.actionEventUnloading(self.baler)
+        if self.balerSpec.platformDropInProgress then 
+            return
+        end
+        if self.balerSpec.isBaleUnloading then 
+            return
+        end
+        if self.balerSpec.unloadingState ~= Baler.UNLOADING_CLOSED then 
+            return
+        end
+    end
+    return true
 end
 
 function BalerController:isThisMyBale(baleObject)

--- a/scripts/ai/controllers/ImplementController.lua
+++ b/scripts/ai/controllers/ImplementController.lua
@@ -93,6 +93,10 @@ function ImplementController:onFinished(hasFinished)
     --- override
 end
 
+function ImplementController:onPreFinished()
+    return true
+end
+
 function ImplementController:onFinishRow(isHeadlandTurn)
 end
 

--- a/scripts/ai/jobs/CpAIJob.lua
+++ b/scripts/ai/jobs/CpAIJob.lua
@@ -58,14 +58,6 @@ function CpAIJob:setupCpJobParameters(jobParameters)
 	self.cpJobParameters:validateSettings()
 end
 
---- Is the ai job allowed to finish ?
---- This entry point allowes us to catch giants stop conditions.
----@param message table Stop reason can be used to reverse engineer the cause.
----@return boolean
-function CpAIJob:isFinishingAllowed(message)
-	return true
-end
-
 --- Gets the first task to start with.
 function CpAIJob:getStartTaskIndex()
 	if self.currentTaskIndex ~= 0 or self.isDirectStart or self:isTargetReached() then
@@ -137,12 +129,8 @@ function CpAIJob:stop(aiMessage)
 	vehicle:deleteAgent()
 	vehicle:aiJobFinished()
 	vehicle:resetCpAllActiveInfoTexts()
-	local driveStrategy = vehicle:getCpDriveStrategy()
 	if not aiMessage then 
 		self:debug("No valid ai message given!")
-		if driveStrategy then
-			driveStrategy:onFinished()
-		end
 		AIJob.stop(self, aiMessage)
 		return
 	end
@@ -159,9 +147,6 @@ function CpAIJob:stop(aiMessage)
 	AIJob.stop(self, aiMessage)
 	if event then
 		SpecializationUtil.raiseEvent(vehicle, event)
-	end
-	if driveStrategy then
-		driveStrategy:onFinished(hasFinished)
 	end
 	g_messageCenter:unsubscribeAll(self)
 end

--- a/scripts/ai/jobs/CpAIJobFieldWork.lua
+++ b/scripts/ai/jobs/CpAIJobFieldWork.lua
@@ -47,29 +47,6 @@ function CpAIJobFieldWork:setupJobParameters()
     self:setupCpJobParameters(CpFieldWorkJobParameters(self))
 end
 
-function CpAIJobFieldWork:isFinishingAllowed(message)
-    local nextTaskIndex = self:getNextTaskIndex()
-	if message:isa(AIMessageErrorOutOfFill) then
-        --- At least one implement type needs to be refilled.
-
-        local vehicle = self:getVehicle()
-        local setting = vehicle:getCpSettings().refillOnTheField
-
-        if setting:getValue() == CpVehicleSettings.REFILL_ON_FIELD_DISABLED then
-            return true
-        elseif setting:getValue() == CpVehicleSettings.REFILL_ON_FIELD_WAITING then
-            if self.currentTaskIndex == self.fieldWorkTask.taskIndex then
-                self.fieldWorkTask:setWaitingForRefillingActive()
-            end
-        elseif setting:getValue() == CpVehicleSettings.REFILL_ON_FIELD_ACTIVE then
-            --- TODO_25 Add driving to trailer for refilling here and so on ..
-            self.fieldWorkTask:skip()
-        end
-        return false
-    end
-    return CpAIJob.isFinishingAllowed(self, message)
-end
-
 ---@param vehicle table
 ---@param mission table
 ---@param farmId number

--- a/scripts/ai/strategies/AIDriveStrategyFieldWorkCourse.lua
+++ b/scripts/ai/strategies/AIDriveStrategyFieldWorkCourse.lua
@@ -108,9 +108,26 @@ function AIDriveStrategyFieldWorkCourse:prepareForFieldWork()
 end
 
 --- Event raised when the driver has finished.
-function AIDriveStrategyFieldWorkCourse:onFinished(hasFinished)
-    AIDriveStrategyCourse.onFinished(self, hasFinished)
+function AIDriveStrategyFieldWorkCourse:onFinished(...)
+    AIDriveStrategyCourse.onFinished(self, ...)
     self.remainingTime:reset()
+end
+
+function AIDriveStrategyFieldWorkCourse:handleFinishedRequest(stopReason)
+    --- TODO consolidate this logic in the future ...
+    if stopReason:isa(AIMessageErrorOutOfFill) then
+        --- At least one implement type needs to be refilled.
+        local setting = self.settings.refillOnTheField
+        if setting:getValue() == CpVehicleSettings.REFILL_ON_FIELD_WAITING then
+            self.currentTask:setWaitingForRefillingActive()
+            return true
+        elseif setting:getValue() == CpVehicleSettings.REFILL_ON_FIELD_ACTIVE then
+            --- TODO_25 Add driving to trailer for refilling here and so on ..
+            self:setFinished(true, nil)
+            return true
+        end
+    end
+    return false
 end
 
 function AIDriveStrategyFieldWorkCourse:update(dt)

--- a/scripts/ai/strategies/AIDriveStrategySiloLoader.lua
+++ b/scripts/ai/strategies/AIDriveStrategySiloLoader.lua
@@ -30,7 +30,7 @@ AIDriveStrategySiloLoader.myStates = {
     DRIVING_ALIGNMENT_COURSE = {},
     WAITING_FOR_PREPARING = {},
     WORKING = {},
-    FINISHED = {}
+    FINISHED_WORKING = {}
 }
 AIDriveStrategySiloLoader.distanceOverFieldEdgeAllowed = 25
 AIDriveStrategySiloLoader.siloAreaOffsetFieldUnload = 10
@@ -201,7 +201,7 @@ function AIDriveStrategySiloLoader:onWaypointPassed(ix, course)
             self.vehicle:raiseAIEvent("onAIFieldWorkerStart", "onAIImplementStart")
             self:lowerImplements()
         elseif self.state == self.states.WORKING then
-            self.state = self.states.FINISHED
+            self.state = self.states.FINISHED_WORKING
         end
     end
 end
@@ -243,11 +243,11 @@ function AIDriveStrategySiloLoader:getDriveData(dt, vX, vY, vZ)
             local isEndReached, maxSpeed = self.bunkerSiloController:isEndReached(self.shovelController:getShovelNode(), 0)
             if self.silo:isTheSameSilo(closestObject) or isEndReached then
                 self:debug("End wall detected or bunker silo end is reached.")
-                self.state = self.states.FINISHED
+                self.state = self.states.FINISHED_WORKING
             end
         end
 
-    elseif self.state == self.states.FINISHED then
+    elseif self.state == self.states.FINISHED_WORKING then
         self:setMaxSpeed(0)
         self:debugSparse("Waiting until the conveyor is empty.")
         if self.shovelController:isEmpty() then

--- a/scripts/specializations/CpAIWorker.lua
+++ b/scripts/specializations/CpAIWorker.lua
@@ -338,34 +338,34 @@ function CpAIWorker:stopCurrentAIJob(superFunc, message, ...)
         return superFunc(self, message, ...)
     end
     
-    local job = self:getJob()
     local wasCpActive = self:getIsCpActive()
-    if wasCpActive then
-        local driveStrategy = self:getCpDriveStrategy()
-        if driveStrategy then
-            -- TODO: this isn't needed if we do not return a 0 < maxSpeed < 0.5, should either be exactly 0 or greater than 0.5
-            local maxSpeed = driveStrategy and driveStrategy:getMaxSpeed()
-            if message:isa(AIMessageErrorBlockedByObject) then
-                if self.spec_aiFieldWorker.didNotMoveTimer and self.spec_aiFieldWorker.didNotMoveTimer < 0 then
-                    if maxSpeed and maxSpeed < 1 then
-                        -- disable the Giants timeout which dismisses the AI worker if it does not move for 5 seconds
-                        -- since we often stop for instance in convoy mode when waiting for another vehicle to turn
-                        -- (when we do this, we set our maxSpeed to 0). So we also check our maxSpeed, this way the Giants timer will
-                        -- fire if we are blocked (thus have a maxSpeed > 0 but not moving)
-                        CpUtil.debugVehicle(CpDebug.DBG_FIELDWORK, self, 'Overriding the Giants did not move timer, with speed: %.2f', maxSpeed)
-                        return
-                    else
-                        CpUtil.debugVehicle(CpDebug.DBG_FIELDWORK, self, 'Giants did not move timer triggered, with speed: %.2f!', maxSpeed)
-                    end
-                end
+    if not wasCpActive then 
+        return superFunc(self, message, ...)
+    end
+    ---@type AIDriveStrategyCourse
+    local driveStrategy = self:getCpDriveStrategy()
+    if not driveStrategy then
+        return superFunc(self, message, ...)
+    end
+    -- TODO: this isn't needed if we do not return a 0 < maxSpeed < 0.5, should either be exactly 0 or greater than 0.5
+    local maxSpeed = driveStrategy and driveStrategy:getMaxSpeed()
+    if message:isa(AIMessageErrorBlockedByObject) then
+        if self.spec_aiFieldWorker.didNotMoveTimer and self.spec_aiFieldWorker.didNotMoveTimer < 0 then
+            if maxSpeed and maxSpeed < 1 then
+                -- disable the Giants timeout which dismisses the AI worker if it does not move for 5 seconds
+                -- since we often stop for instance in convoy mode when waiting for another vehicle to turn
+                -- (when we do this, we set our maxSpeed to 0). So we also check our maxSpeed, this way the Giants timer will
+                -- fire if we are blocked (thus have a maxSpeed > 0 but not moving)
+                CpUtil.debugVehicle(CpDebug.DBG_FIELDWORK, self, 'Overriding the Giants did not move timer, with speed: %.2f', maxSpeed)
+                return
+            else
+                CpUtil.debugVehicle(CpDebug.DBG_FIELDWORK, self, 'Giants did not move timer triggered, with speed: %.2f!', maxSpeed)
             end
         end
-        if not job:isFinishingAllowed(message) then
-            return
-        end
     end
-    CpUtil.debugVehicle(CpDebug.DBG_FIELDWORK, self, "stop message: %s", message:getI18NText())
-    superFunc(self, message,...)
+    local releaseMessage, hasFinished, event, isOnlyShownOnPlayerStart = 
+        g_infoTextManager:getInfoTextDataByAIMessage(message)
+    driveStrategy:onFinished(hasFinished, message)
 end
 
 --- Sets a stop flag to make the driver stop after the worker finished.


### PR DESCRIPTION
- Now every ``vehicle:stopCurrentAIJob()`` call gets passed back to the current drive stategy and can be evaluated there.
- This enabled a proper solution to wait for finishing event, like for example folding of implements or specific action like unloading of a baler and so on ...