### PR TITLE
fix: fill level for harvesters

### DIFF
--- a/scripts/ai/controllers/CombineController.lua
+++ b/scripts/ai/controllers/CombineController.lua
@@ -27,12 +27,20 @@ function CombineController:getDriveData()
 end
 
 function CombineController:getFillLevel()
-    return self.implement:getFillUnitFillLevel(self.combineSpec.fillUnitIndex)
+    local fillLevel = self.implement:getFillUnitFillLevel(self.combineSpec.fillUnitIndex)
+    if self.combineSpec.loadingDelay > 0 then
+        for i=1, #self.combineSpec.loadingDelaySlots do
+            local slot = self.combineSpec.loadingDelaySlots[i]
+            if slot.valid then
+                fillLevel = fillLevel + slot.fillLevelDelta
+            end
+        end
+    end
+    return fillLevel
 end
 
 function CombineController:getFillLevelPercentage()
-    return 100 * self.implement:getFillUnitFillLevel(self.combineSpec.fillUnitIndex) /
-            self.implement:getFillUnitCapacity(self.combineSpec.fillUnitIndex)
+    return 100 * self:getFillLevel() / self:getCapacity()
 end
 
 function CombineController:getCapacity()

--- a/scripts/ai/strategies/AIDriveStrategyCombineCourse.lua
+++ b/scripts/ai/strategies/AIDriveStrategyCombineCourse.lua
@@ -806,8 +806,8 @@ function AIDriveStrategyCombineCourse:estimateDistanceUntilFull(ix)
             self.litersPerMeter = 0
             self.litersPerSecond = 0
         end
-        self:debug('Fill rate is %.1f l/m, %.1f l/s (fill level %.1f, last %.1f, dToNext = %.1f)',
-                self.litersPerMeter, self.litersPerSecond, fillLevel, self.fillLevelAtLastWaypoint, dToNext)
+        self:debug('Fill rate is %.1f l/m, %.1f l/s (fill level %.1f of %.1f, last %.1f, dToNext = %.1f)',
+                self.litersPerMeter, self.litersPerSecond, fillLevel, capacity, self.fillLevelAtLastWaypoint, dToNext)
         self.fillLevelLastCheckedTime = g_currentMission.time
         self.fillLevelAtLastWaypoint = fillLevel
     end


### PR DESCRIPTION
At many harvesters, especially potato and other
root vegetable harvesters, the fruit needs a long
time to get from the ground to the tank.

This means there's a significant amount of fruit
harvested but not showing up in the tank's fill
level.

Add all fruit already harvested to the fill level
so we stop the moment enough fruit is harvested to reach 100%.

#357