### PR TITLE
Fixes bug, where the silo end is detected with a 180 degree angree fo…

### DIFF
--- a/scripts/ai/strategies/AIDriveStrategyShovelSiloLoader.lua
+++ b/scripts/ai/strategies/AIDriveStrategyShovelSiloLoader.lua
@@ -647,7 +647,13 @@ function AIDriveStrategyShovelSiloLoader:startDrivingToSilo(target)
     local dx, dz = unpack(endPos)
     local siloCourse = Course.createFromTwoWorldPositions(self.vehicle, x, z, dx, dz,
             0, -5, 3, 3, false)
-    if self.siloController:isSameDirection(AIUtil.getDirectionNode(self.vehicle)) then 
+    local vx, _, vz = getWorldTranslation(AIUtil.getDirectionNode(self.vehicle))
+    local dx, _, dz = siloCourse:worldToWaypointLocal(1, vx, 0, vz)
+    if dz < 0 and dz > -self.maxDistanceWithoutPathfinding and 
+        math.abs(dx) <= math.abs(dz) and 
+        math.abs(dx) < self.maxDistanceWithoutPathfinding * math.sqrt(2)/2 and 
+        self.siloController:isSameDirection(AIUtil.getDirectionNode(self.vehicle)) then
+         
         self:debug("Start driving into the silo directly.")
         self:startCourse(siloCourse, 1)
         self:setNewState(self.states.DRIVING_INTO_SILO)

--- a/scripts/silo/BunkerSiloVehicleController.lua
+++ b/scripts/silo/BunkerSiloVehicleController.lua
@@ -229,6 +229,18 @@ function CpBunkerSiloVehicleController:isEndReached(node, margin)
 	return false, math.huge
 end
 
+--- Check if the drive target direction is within 45° relative to the given node.
+--- @param node number
+--- @return boolean
+function CpBunkerSiloVehicleController:isSameDirection(node)
+	if not self.drivingTarget then
+		return false
+	end
+	local dx, dz = unpack(self.drivingTarget[2])
+	local x, _, z = localToWorld(node, 0, 0, 0)
+	return math.abs(MathUtil.getYRotationFromDirection(x - dx, z - dz)) < math.pi/2
+end
+
 --- Generates a silo map with lines and a map with rectangle tiles.
 ---@param width number
 ---@param unitWidth number


### PR DESCRIPTION
…r the unload relative to the silo
#612 
- Testing:
  - Starting driving into the silo with different angles.
  - Unload marker set roughly 180 degree turned compared to the silo loading point.
  -  Check if the ending of a silo, with both open sides, is still detected.