### PR TITLE
786 oxbo pea harvester headland turn

### DIFF
--- a/config/VehicleConfigurations.xml
+++ b/config/VehicleConfigurations.xml
@@ -202,6 +202,7 @@ You can define the following custom settings:
         <Configuration type="BOOL">openPipeEarly</Configuration>
         <Configuration type="BOOL">closePipeAfterUnload</Configuration>
         <Configuration type="INT">tipSideIndex</Configuration>
+        <Configuration type="BOOL">disablePocket</Configuration>
 	</Configurations>
     <!--[GIANTS]-->
 

--- a/config/VehicleConfigurations.xml
+++ b/config/VehicleConfigurations.xml
@@ -80,7 +80,7 @@ You can define the following custom settings:
 - lowerEarly: boolean
     Similar to the above, the default behavior when starting to work is lower the implement when the back of the
     work area reaches to row start/field edge. Setting this to true will make Courseplay lower the implement as
-    soon as the the front reaches the row start/field edge, avoiding unworked patches with irregular implement
+    soon as the front reaches the row start/field edge, avoiding unworked patches with irregular implement
     work areas such as a plow.
 
 - useVehicleSizeForMarkers: boolean

--- a/config/VehicleConfigurations.xml
+++ b/config/VehicleConfigurations.xml
@@ -163,6 +163,13 @@ You can define the following custom settings:
     Forced tip side index for unloading. For now only for an auger wagon.
     As an example the Hawe SUW 5000 has two tipside, but only the one with the pipe is needed. 
 
+- disablePocket: boolean
+    Disables creating a pocket for headland turns. Some harvesters, like mostly potato and other root vegetable
+    harvesters, are not good at making a pocket at the headland corner as they are very long but have a small
+    working width. We automatically try to disable pocket for most of the root vegetable harvesters, but some,
+    like the Oxbo, are not detected correctly. This setting can be used to disable the pocket creation for these
+    harvesters.
+
 -->
 <VehicleConfigurations>
 	<Configurations>

--- a/config/VehicleConfigurations.xml
+++ b/config/VehicleConfigurations.xml
@@ -237,12 +237,15 @@ You can define the following custom settings:
     <!--\vehicles\oxbo-->
     <Vehicle name="mkb4TR.xml"
              closePipeAfterUnload = "true"
+             disablePocket = "true"
     />
     <Vehicle name="bp2140e.xml"
              closePipeAfterUnload = "true"
+             disablePocket = "true"
     />
     <Vehicle name="epd540E.xml"
              closePipeAfterUnload = "true"
+             disablePocket = "true"
     />
 
     <!-- Implements -->

--- a/scripts/Course.lua
+++ b/scripts/Course.lua
@@ -915,13 +915,13 @@ function Course:extend(length, dx, dz)
     for i = first, last, step do
         local x = lastWp.x + dx * i
         local z = lastWp.z + dz * i
-        self:appendWaypoint({ x = x, z = z })
+        self:appendWaypoint({ x = x, z = z, rev = lastWp.rev })
     end
     if length % step > 0 then
         -- add the remainder to make sure we extend all the way up to length
         local x = lastWp.x + dx * length
         local z = lastWp.z + dz * length
-        self:appendWaypoint({ x = x, z = z })
+        self:appendWaypoint({ x = x, z = z, rev = lastWp.rev })
     end
     -- enrich the waypoints we added
     self:enrichWaypointData(nWaypoints)

--- a/scripts/Course.lua
+++ b/scripts/Course.lua
@@ -648,6 +648,10 @@ function Course:isLastWaypointIx(ix)
     return #self.waypoints == ix
 end
 
+function Course:endsInReverse()
+    return self:isReverseAt(self:getNumberOfWaypoints())
+end
+
 function Course:print()
     for i = 1, #self.waypoints do
         local p = self.waypoints[i]

--- a/scripts/CpUtil.lua
+++ b/scripts/CpUtil.lua
@@ -466,7 +466,7 @@ function CpUtil.getAllRootVegetables()
         local preparedGrowthState = fruitTypeData.preparedGrowthState
         local name = fruitTypeData.name
 
-        -- check if fruit is needs herb removement to be harvested
+        -- check if fruit is needs herb removal to be harvested
         if minPreparingGrowthState ~= -1 and preparedGrowthState ~= -1 and name ~= "SUGARCANE" then
 			local fruitType = g_fruitTypeManager:getFruitTypeByName(name)
             if fruitType ~= nil then

--- a/scripts/ai/controllers/CombineController.lua
+++ b/scripts/ai/controllers/CombineController.lua
@@ -128,20 +128,6 @@ function CombineController:isDroppingStrawSwath()
     return self.combineSpec.strawPSenabled
 end
 
-function CombineController:isRootVegetableHarvester()
-    for _, fruitTypeIndex in pairs(CpUtil.getAllRootVegetables()) do
-        local fillUnitIndex = g_fruitTypeManager:getFillTypeIndexByFruitTypeIndex(fruitTypeIndex)
-        self:debug("check if fruitType %s is supported", g_fillTypeManager:getFillTypeNameByIndex(fillUnitIndex))
-        for i, _ in ipairs(self.implement:getFillUnits()) do
-            if self.implement:getFillUnitSupportsFillType(i, fillUnitIndex) then
-                self:debug('This is a root vegetable harvester.')
-                return true
-            end
-        end
-    end
-    return false
-end
-
 --- Is this a towed harvester? We don't want these to make combine headland turns (or make pockets?)
 function CombineController:isTowed()
     return self.isWheeledImplement

--- a/scripts/ai/controllers/CombineController.lua
+++ b/scripts/ai/controllers/CombineController.lua
@@ -128,6 +128,20 @@ function CombineController:isDroppingStrawSwath()
     return self.combineSpec.strawPSenabled
 end
 
+function CombineController:isRootVegetableHarvester()
+    for _, fruitTypeIndex in pairs(CpUtil.getAllRootVegetables()) do
+        local fillUnitIndex = g_fruitTypeManager:getFillTypeIndexByFruitTypeIndex(fruitTypeIndex)
+        self:debug("check if fruitType %s is supported", g_fillTypeManager:getFillTypeNameByIndex(fillUnitIndex))
+        for i, _ in ipairs(self.implement:getFillUnits()) do
+            if self.implement:getFillUnitSupportsFillType(i, fillUnitIndex) then
+                self:debug('This is a root vegetable harvester.')
+                return true
+            end
+        end
+    end
+    return false
+end
+
 --- Is this a towed harvester? We don't want these to make combine headland turns (or make pockets?)
 function CombineController:isTowed()
     return self.isWheeledImplement

--- a/scripts/ai/strategies/AIDriveStrategyCombineCourse.lua
+++ b/scripts/ai/strategies/AIDriveStrategyCombineCourse.lua
@@ -1416,7 +1416,8 @@ function AIDriveStrategyCombineCourse:startTurn(ix)
             self:debug('Headland turn but this a connecting track, use normal turn maneuvers.')
             AIDriveStrategyFieldWorkCourse.startTurn(self, ix)
         elseif self.course:isOnOutermostHeadland(ix) and self:isTurnOnFieldActive() and
-                not self.combineController:isRootVegetableHarvester()then
+                not self.combineController:isRootVegetableHarvester() and
+                not g_vehicleConfigurations:getRecursively(self.vehicle, 'disablePocket') then
             self:debug('Creating a pocket in the corner so the combine stays on the field during the turn')
             self.aiTurn = CombinePocketHeadlandTurn(self.vehicle, self, self.ppc, self.proximityController, self.turnContext,
                     self.course, self:getWorkWidth())

--- a/scripts/ai/strategies/AIDriveStrategyCombineCourse.lua
+++ b/scripts/ai/strategies/AIDriveStrategyCombineCourse.lua
@@ -1412,13 +1412,6 @@ function AIDriveStrategyCombineCourse:startTurn(ix)
         if self.combineController:isTowed() then
             self:debug('Headland turn but this is a towed harvester using normal turn maneuvers.')
             AIDriveStrategyFieldWorkCourse.startTurn(self, ix)
-            -- The type of fruit being harvested isn't really the indicator if we can make a headland turn
-            -- TODO: either make disabling combine headland turns configurable, or
-            -- TODO: decide automatically based on the vehicle's properties, like turn radius, work width, etc.
-            -- and disable when such a turn does not make sense for the vehicle.
-        elseif self.combineController:isRootVegetableHarvester() then
-            self:debug('Headland turn but this harvester uses normal turn maneuvers.')
-            AIDriveStrategyFieldWorkCourse.startTurn(self, ix)
         elseif self.course:isOnConnectingPath(ix) then
             self:debug('Headland turn but this a connecting track, use normal turn maneuvers.')
             AIDriveStrategyFieldWorkCourse.startTurn(self, ix)

--- a/scripts/ai/strategies/AIDriveStrategyCombineCourse.lua
+++ b/scripts/ai/strategies/AIDriveStrategyCombineCourse.lua
@@ -1415,7 +1415,8 @@ function AIDriveStrategyCombineCourse:startTurn(ix)
         elseif self.course:isOnConnectingPath(ix) then
             self:debug('Headland turn but this a connecting track, use normal turn maneuvers.')
             AIDriveStrategyFieldWorkCourse.startTurn(self, ix)
-        elseif self.course:isOnOutermostHeadland(ix) and self:isTurnOnFieldActive() then
+        elseif self.course:isOnOutermostHeadland(ix) and self:isTurnOnFieldActive() and
+                not self.combineController:isRootVegetableHarvester()then
             self:debug('Creating a pocket in the corner so the combine stays on the field during the turn')
             self.aiTurn = CombinePocketHeadlandTurn(self.vehicle, self, self.ppc, self.proximityController, self.turnContext,
                     self.course, self:getWorkWidth())

--- a/scripts/ai/turns/AITurn.lua
+++ b/scripts/ai/turns/AITurn.lua
@@ -762,7 +762,7 @@ end
 
 function CombineHeadlandTurn:startTurn()
     self:debug('Starting a combine headland turn')
-    self.turnCourse = ReedsSheppHeadlandTurn(self.vehicle, self.turnContext,
+    self.turnCourse = ReedsSheppHeadlandTurnManeuver(self.vehicle, self.turnContext,
             self.vehicle:getAIDirectionNode(), self.turningRadius):getCourse()
     self.state = self.states.TURNING
     self.ppc:setCourse(self.turnCourse)

--- a/scripts/ai/turns/AITurn.lua
+++ b/scripts/ai/turns/AITurn.lua
@@ -763,7 +763,7 @@ end
 function CombineHeadlandTurn:startTurn()
     self:debug('Starting a combine headland turn')
     self.turnCourse = ReedsSheppHeadlandTurn(self.vehicle, self.turnContext,
-            self.turnContext.vehicleAtTurnStartNode, self.turningRadius):getCourse()
+            self.vehicle:getAIDirectionNode(), self.turningRadius):getCourse()
     self.state = self.states.TURNING
     self.ppc:setCourse(self.turnCourse)
     self.ppc:initialize(1)

--- a/scripts/ai/turns/TurnContext.lua
+++ b/scripts/ai/turns/TurnContext.lua
@@ -367,19 +367,6 @@ function TurnContext:createCorner(vehicle, r)
             vehicle:getCpSettings().toolOffsetX:getValue())
 end
 
---- Course to reverse before starting a turn to make sure the turn is completely on the field
---- @param vehicle table
---- @param reverseDistance number distance to reverse in meters
-function TurnContext:createReverseWaypointsBeforeStartingTurn(vehicle, reverseDistance)
-    local reverserNode = AIUtil.getReverserNode(vehicle)
-    local _, _, dStart = localToLocal(reverserNode or vehicle:getAIDirectionNode(), self.workEndNode, 0, 0, 0)
-    local waypoints = {}
-    for d = dStart, dStart - reverseDistance - 1, -1 do
-        local x, y, z = localToWorld(self.workEndNode, 0, 0, d)
-        table.insert(waypoints, {x = x, y = y, z = z, rev = true})
-    end
-    return waypoints
-end
 
 --- Course to end a pathfinder turn, a straight line from where pathfinder ended, into to next row,
 --- making sure it is long enough so the vehicle reaches the point to lower the implements on this course

--- a/scripts/ai/turns/TurnManeuver.lua
+++ b/scripts/ai/turns/TurnManeuver.lua
@@ -552,13 +552,13 @@ function ReedsSheppTurnManeuver:findAnalyticPath(vehicleDirectionNode, startXOff
     return course
 end
 
----@class ReedsSheppHeadlandTurn : TurnManeuver
-ReedsSheppHeadlandTurn = CpObject(TurnManeuver)
+---@class ReedsSheppHeadlandTurnManeuver : TurnManeuver
+ReedsSheppHeadlandTurnManeuver = CpObject(TurnManeuver)
 
 --- This is a headland turn (~90 degrees) for non-towed harvesters with cutter on the front. Expected to be called
 --- just after the cutter finished the corner, that is, the harvester should drive forward in the original direction
 --- until there is no fruit left. It'll then do a quick 90 degree 3 point turn to align with the new direction.
-function ReedsSheppHeadlandTurn:init(vehicle, turnContext, vehicleDirectionNode, turningRadius)
+function ReedsSheppHeadlandTurnManeuver:init(vehicle, turnContext, vehicleDirectionNode, turningRadius)
     local solver = ReedsSheppSolver()
     -- use lateWorkStartNode since we covered the corner in the inbound direction already
     local path = PathfinderUtil.findAnalyticPath(solver, vehicleDirectionNode, 0, 0,
@@ -567,7 +567,7 @@ function ReedsSheppHeadlandTurn:init(vehicle, turnContext, vehicleDirectionNode,
     self.course:adjustForReversing(2)
     -- add a little straight section to the end so we have a little buffer and don't end the turn right at
     -- the work start
-    self.course:extend(5)
+    self.course:extend(self:getReversingOffset() + 1)
     TurnManeuver.setLowerImplements(self.course, 5, true)
 end
 

--- a/scripts/ai/turns/TurnManeuver.lua
+++ b/scripts/ai/turns/TurnManeuver.lua
@@ -565,6 +565,10 @@ function ReedsSheppHeadlandTurn:init(vehicle, turnContext, vehicleDirectionNode,
             turnContext.lateWorkStartNode, 0, -turnContext.backMarkerDistance, turningRadius)
     self.course = Course.createFromAnalyticPath(vehicle, path, true)
     self.course:adjustForReversing(2)
+    -- add a little straight section to the end so we have a little buffer and don't end the turn right at
+    -- the work start
+    self.course:extend(5)
+    TurnManeuver.setLowerImplements(self.course, 5, true)
 end
 
 ---@class TurnEndingManeuver : TurnManeuver


### PR DESCRIPTION
Use a Reeds-Shepp turn instead of the old combine
headland turn which used angles and relative
distances to steer the vehicle.