### PR TITLE
perf: collision avoidance controller

### DIFF
--- a/scripts/Course.lua
+++ b/scripts/Course.lua
@@ -1330,23 +1330,25 @@ end
 
 --- Check if our course intersects otherCourse
 ---@param otherCourse Course
----@param lookahead number distance in meters we want to traverse on our course to check for an intersection
----@param startAtCurrentWaypoint boolean if true, start checking at the current waypoint on both courses,
---- otherwise at the first waypoint
+---@param lookahead number distance in meters we want to traverse on our course and on the other course
+--- to check for an intersection. The search always starts at the current waypoint of each course
 ---@return number, number distance on my course to the intersection point (or nil when there is no intersection),
 --- distance on the other course until the intersection point.
-function Course:intersects(otherCourse, lookahead, startAtCurrentWaypoint)
+function Course:intersects(otherCourse, lookahead)
     local myDistance = 0
-    for i = startAtCurrentWaypoint and self:getCurrentWaypointIx() or 1, #self.waypoints - 1 do
+    for i = self:getCurrentWaypointIx() , #self.waypoints - 1 do
         local m1, m2 = self.waypoints[i], self.waypoints[i + 1]
         myDistance = myDistance + m2.dToHere - m1.dToHere
         local otherDistance = 0
-        for j = startAtCurrentWaypoint and otherCourse:getCurrentWaypointIx() or 1, #otherCourse.waypoints - 1 do
+        for j = otherCourse:getCurrentWaypointIx(), #otherCourse.waypoints - 1 do
             local o1, o2 = otherCourse.waypoints[j], otherCourse.waypoints[j + 1]
             otherDistance = otherDistance + o2.dToHere - o1.dToHere
             if CpMathUtil.getIntersectionPoint(m1.x, m1.z, m2.x, m2.z, o1.x, o1.z, o2.x, o2.z) then
                 -- these sections intersect
                 return myDistance, otherDistance
+            end
+            if otherDistance > lookahead then
+                break
             end
         end
         if myDistance > lookahead then


### PR DESCRIPTION
If a harvester has an insanely long course, the
collision avoidance controller, while looking for an intersection between the unloader and the harvester's course, iterated until the end of the harvester's
which caused significant slowdowns.

Limit the lookahead for the collision avoidance
controller: always start checking for intersections at the current waypoint of the unloader and the
harvester, and stop looking after the lookahead
distance.

#871