### PR TITLE
fix: more robust harvester back measurement

### DIFF
--- a/scripts/CpUtil.lua
+++ b/scripts/CpUtil.lua
@@ -492,6 +492,10 @@ function CpUtil.getDefaultCollisionFlags()
 		CollisionFlag.VEHICLE + CollisionFlag.BUILDING + CollisionFlag.STATIC_OBJECT
 end
 
+function CpUtil.getVehicleCollisionFlags()
+	return CollisionFlag.VEHICLE
+end
+
 --- Removes all event listeners of a given Spec Class.
 function CpUtil.removeEventListenersBySpecialization(vehicle, specClass)
 	for _, listeners in pairs(vehicle.eventListeners) do

--- a/scripts/ai/Markers.lua
+++ b/scripts/ai/Markers.lua
@@ -45,7 +45,7 @@ local function setBackMarkerNode(vehicle, measuredBackDistance)
         lastImplement, backMarkerOffset = AIUtil.getLastAttachedImplement(vehicle)
         referenceNode = AIUtil.getDirectionNode(vehicle)
         CpUtil.debugVehicle(CpDebug.DBG_IMPLEMENTS, vehicle, 'Using the last implement\'s rear distance for the back marker node, %d m from root node', backMarkerOffset)
-    elseif measuredBackDistance then
+    elseif measuredBackDistance and measuredBackDistance ~= 0 then
         referenceNode = AIUtil.getDirectionNode(vehicle)
         backMarkerOffset = -measuredBackDistance
         CpUtil.debugVehicle(CpDebug.DBG_IMPLEMENTS, vehicle, 'back marker node on measured back distance %.1f', measuredBackDistance)

--- a/scripts/ai/parameters/AIParameterSettingList.lua
+++ b/scripts/ai/parameters/AIParameterSettingList.lua
@@ -394,7 +394,7 @@ end
 ---@return boolean value is not valid and could not be set.
 function AIParameterSettingList:setFloatValue(value, epsilon, noEventSend)
 	local failed = setValueInternal(self, value, function(a, b)
-		local epsilon = epsilon or self.data.incremental or 0.1
+		epsilon = epsilon or self.data.incremental or 0.1
 		if a == nil or b == nil then return false end
 		return a > b - epsilon / 2 and a <= b + epsilon / 2 end)
 	if not failed and not noEventSend then
@@ -450,7 +450,7 @@ function AIParameterSettingList:setDefault(noEventSend)
 				local value = g_vehicleConfigurations:get(object, configName)
 				if value then 
 					if tonumber(value) then 
-						self:setFloatValue(value, noEventSend)
+						self:setFloatValue(value, nil, noEventSend)
 					else
 						self:setValue(value, noEventSend)
 					end
@@ -462,7 +462,7 @@ function AIParameterSettingList:setDefault(noEventSend)
 	end
 	--- If default values were setup use these.
 	if self.data.default ~=nil then
-		AIParameterSettingList.setFloatValue(self, self.data.default, noEventSend)
+		AIParameterSettingList.setFloatValue(self, self.data.default, nil, noEventSend)
 		self:debug("set to default %s", self.data.default)
 		return
 	end

--- a/scripts/courseGenerator/Headland.lua
+++ b/scripts/courseGenerator/Headland.lua
@@ -190,7 +190,7 @@ function Headland:connectTo(other, ix, workingWidth, turningRadius, headlandFirs
                         length, transitionEndIx, i)
                 return transitionEndIx
             else
-                self.logger:warning('Generated path to next headland too long (%.1f > %.1f), try %d.',
+                self.logger:debug('Generated path to next headland too long (%.1f > %.1f), try %d.',
                         length, maxPlausiblePathLength, i)
             end
             if 0.8 * radius > turningRadius then


### PR DESCRIPTION
Measuring the length of harvesters with raycast did not work as expected, because some, like the Oxbo is "transparent" at the default 1.5 m height.

Measure at multiple heights, also consider side offset for towed harvesters now. Measure every 10 seconds to account for a towed harvester at an angle when starting.

Should help with unloaders approaching the harvesters from further back.

#940