### PR TITLE
fix: consider fruit avoidance setting for transitions

### DIFF
--- a/scripts/ai/PathfinderController.lua
+++ b/scripts/ai/PathfinderController.lua
@@ -66,7 +66,7 @@ function Strategy:onPathfindingFailed(controller : PathfinderController, current
 	fruitPenaltyNodePercent : number, offFieldPenaltyNodePercent : number)
 	if currentRetryAttempt == 1 then 
 		// try whatever has better chances:
-		currentContext:ignoreFruit()
+		currentContext:ignoreFruit(true)
 		self.pathfinderController:findPathToNode(currentContext, ...)
 	else 
 		// Something else ...

--- a/scripts/ai/strategies/AIDriveStrategyAttachHeader.lua
+++ b/scripts/ai/strategies/AIDriveStrategyAttachHeader.lua
@@ -239,7 +239,7 @@ function AIDriveStrategyAttachHeader:startPathfindingToCutter()
         local context = PathfinderContext(self.vehicle)
         context:mustBeAccurate(false):allowReverse(true):offFieldPenalty(0)
         context:vehiclesToIgnore({ self.vehicle }):areaToAvoid(self.trailerAreaToAvoid)
-        context:ignoreFruit()
+        context:ignoreFruit(true)
         local result
         self.pathfinder, result = PathfinderUtil.startPathfindingFromVehicleToNode(
                 self.cutterNode, 0, -math.max(1.5 * length, 1.5 * self.turningRadius), context)

--- a/scripts/ai/strategies/AIDriveStrategyDriveToFieldWorkStart.lua
+++ b/scripts/ai/strategies/AIDriveStrategyDriveToFieldWorkStart.lua
@@ -202,8 +202,8 @@ end
 ---@param wasLastRetry boolean
 ---@param currentRetryAttempt number
 function AIDriveStrategyDriveToFieldWorkStart:onPathfindingFailed(controller, lastContext, wasLastRetry, currentRetryAttempt)
-    self:debug('Failed to find a path, trying with a reduced off-field penalty and no fruit avoidence again')
-    lastContext:offFieldPenalty(PathfinderContext.defaultOffFieldPenalty / 2):ignoreFruit():ignoreFruitHeaps()
+    self:debug('Failed to find a path, trying with a reduced off-field penalty and no fruit avoidance again')
+    lastContext:offFieldPenalty(PathfinderContext.defaultOffFieldPenalty / 2):ignoreFruit(true):ignoreFruitHeaps()
     controller:retry(lastContext)
 end
 

--- a/scripts/ai/strategies/AIDriveStrategyFieldWorkCourse.lua
+++ b/scripts/ai/strategies/AIDriveStrategyFieldWorkCourse.lua
@@ -505,7 +505,9 @@ function AIDriveStrategyFieldWorkCourse:returnToStartAfterDone()
     if not self.pathfinder or not self.pathfinder:isActive() then
         self.pathfindingStartedAt = g_currentMission.time
         self:debug('Return to first waypoint')
-        local context = PathfinderContext(self.vehicle):allowReverse(self:getAllowReversePathfinding())
+        local context = PathfinderContext(self.vehicle)
+                :allowReverse(self:getAllowReversePathfinding())
+                :ignoreFruit(not self.settings.avoidFruit:getValue())
         local result
         self.pathfinder, result = PathfinderUtil.startPathfindingFromVehicleToWaypoint(
                 self.fieldWorkCourse, 1, 0, 0, context)
@@ -545,7 +547,9 @@ function AIDriveStrategyFieldWorkCourse:startPathfindingToNextWaypoint(ix)
             self.turnNodes, self:getWorkWidth(), fm, bm, self:getTurnEndSideOffset(false), self:getTurnEndForwardOffset())
     local _, steeringLength = AIUtil.getSteeringParameters(self.vehicle)
     local targetNode, zOffset = self.turnContext:getTurnEndNodeAndOffsets(steeringLength)
-    local context = PathfinderContext(self.vehicle):allowReverse(self:getAllowReversePathfinding())
+    local context = PathfinderContext(self.vehicle)
+            :allowReverse(self:getAllowReversePathfinding())
+            :ignoreFruit(not self.settings.avoidFruit:getValue())
     self.waypointToContinueOnFailedPathfinding = ix + 1
     self.pathfinderController:registerListeners(self, self.onPathfindingDoneToNextWaypoint,
             self.onPathfindingFailedToNextWaypoint)
@@ -609,7 +613,7 @@ function AIDriveStrategyFieldWorkCourse:startConnectingPath(ix)
         local _, steeringLength = AIUtil.getSteeringParameters(self.vehicle)
         local targetNode, zOffset = self.turnContext:getTurnEndNodeAndOffsets(steeringLength)
         local context = PathfinderContext(self.vehicle):allowReverse(self:getAllowReversePathfinding())
-        context:preferredPath(connectingPath):mustBeAccurate(true)
+        context:preferredPath(connectingPath):mustBeAccurate(true):ignoreFruit(not self.settings.avoidFruit:getValue())
         if #connectingPath < 2 then
             self:debug('Connecting path has only %d waypoint, use an alignment course instead', #connectingPath)
             self.workStarterCourse = self:createAlignmentCourse(self.fieldWorkCourse, targetWaypointIx)

--- a/scripts/ai/strategies/AIDriveStrategyShovelSiloLoader.lua
+++ b/scripts/ai/strategies/AIDriveStrategyShovelSiloLoader.lua
@@ -610,7 +610,7 @@ function AIDriveStrategyShovelSiloLoader:onPathfindingFailed(controller,
     if self.state == self.states.DRIVING_ALIGNMENT_COURSE then 
         local course = self:getRememberedCourseAndIx()
         local fm = self:getFrontAndBackMarkers()
-        lastContext:ignoreFruit()
+        lastContext:ignoreFruit(true)
         controller:findPathToWaypoint(lastContext, course, 
             1, 0, -(fm + 4), 1)
     elseif self.state == self.states.DRIVING_TO_UNLOAD_POSITION then 

--- a/scripts/ai/strategies/AIDriveStrategySiloLoader.lua
+++ b/scripts/ai/strategies/AIDriveStrategySiloLoader.lua
@@ -300,7 +300,7 @@ function AIDriveStrategySiloLoader:startPathfindingToStart(course)
     self.state = self.states.DRIVING_ALIGNMENT_COURSE
     self:rememberCourse(course, 1)
     local fm = self:getFrontAndBackMarkers()
-    local context = PathfinderContext(self.vehicle):allowReverse(true):ignoreFruit()
+    local context = PathfinderContext(self.vehicle):allowReverse(true):ignoreFruit(true)
     self.pathfinderController:findPathToWaypoint(context, course,
             1, 0, -1.5 * (fm + 4), 1)
 end

--- a/scripts/pathfinder/PathfinderContext.lua
+++ b/scripts/pathfinder/PathfinderContext.lua
@@ -113,9 +113,9 @@ function PathfinderContext:init(vehicle)
     CpObjectUtil.registerBuilderAPI(self, self.attributesToDefaultValue)
 end
 
---- Disables the fruit avoidance
-function PathfinderContext:ignoreFruit()
-    self._maxFruitPercent = math.huge
+--- Disables the fruit avoidance if true, otherwise sets the default value.
+function PathfinderContext:ignoreFruit(ignore)
+    self._maxFruitPercent = ignore and math.huge or PathfinderContext.attributesToDefaultValue.maxFruitPercent
     return self
 end
 


### PR DESCRIPTION
We conveniently ignored the vehicle's fruit avoidance setting when creating the pathfinder context for the headland-center and block-block connecting paths.

Pathfinder now ignores fruit when the avoid driving in fruit setting for the vehicle is deactivated.