### PR TITLE
docs: update README, modDesc and issue templates with website links

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT_DE.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT_DE.yml
@@ -7,15 +7,18 @@ body:
   attributes:
     value: 'Danke, dass du dir Zeit nimmst, diesen Bugreport auszufüllen.
 
-      Lies dir bitte zuerst unsere [Wiki Seite](https://github.com/Courseplay/Courseplay_FS25/wiki)
+      Lies dir bitte zuerst unsere [Wiki-Seite](https://github.com/Courseplay/Courseplay_FS25/wiki)
       durch, bevor du ein neues Issue erstellst!
+
+      Unsere Hilfe aus dem Spiel gibt es auch auf der [CP-Website](https://courseplay.github.io/CourseplayHelpFS25/de/),
+      dort kannst du bereits vieles zu Courseplay erfahren!
 
       '
 - type: dropdown
   id: mod-version
   attributes:
     label: Version
-    description: Welche CP Version verwendest du?
+    description: Welche CP-Version verwendest du?
     options:
     - '0'
     - 8.0.0.0
@@ -113,7 +116,7 @@ body:
   id: screenshots
   attributes:
     label: Screenshots
-    description: Ziehe deine Screenshots in das Textfeld, um diese hoch zu laden.
+    description: Ziehe deine Screenshots in das Textfeld, um diese hochzuladen.
     placeholder: Wenn du Screenshots hast, die helfen dein Problem zu beschreiben,
       füge sie hier ein.
   validations:

--- a/.github/ISSUE_TEMPLATE/BUG_REPORT_EN.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT_EN.yml
@@ -10,6 +10,9 @@ body:
       Please make sure to read our [Wiki Page](https://github.com/Courseplay/Courseplay_FS25/wiki)
       before creating a new issue!
 
+      You can also find our in-game help pages on the [Courseplay website](https://courseplay.github.io/CourseplayHelpFS25/),
+      which includes lots of useful information that may help with your problem.
+
       '
 - type: dropdown
   id: mod-version

--- a/.github/ISSUE_TEMPLATE/QUESTION_DE.yml
+++ b/.github/ISSUE_TEMPLATE/QUESTION_DE.yml
@@ -7,10 +7,10 @@ body:
   attributes:
     value: 'Bitte benutze diese Vorlage, um deine Frage zu stellen!
 
-      Lese dir bitte zuerst unsere [Wiki Seite](https://github.com/Courseplay/Courseplay_FS25/wiki)
+      Lies dir bitte zuerst unsere [Wiki-Seite](https://github.com/Courseplay/Courseplay_FS25/wiki)
       durch, bevor du ein neues Issue erstellst!
 
-      Unsere Hilfe aus dem Spiel, gibt es auch unter [Courseplay.dev]!(https://courseplay.github.io/Courseplay_FS22.github.io/),
+      Unsere Hilfe aus dem Spiel gibt es auch auf der [CP-Website](https://courseplay.github.io/CourseplayHelpFS25/de/),
       dort kannst du bereits vieles zu Courseplay erfahren!
 
       '
@@ -18,7 +18,7 @@ body:
   id: mod-version
   attributes:
     label: Version
-    description: Welche CP Version verwendest du?
+    description: Welche CP-Version verwendest du?
     options:
     - '0'
     - 8.0.0.0
@@ -64,11 +64,11 @@ body:
   id: about
   attributes:
     label: Um was geht es bei deiner Frage?
-    description: Bitte wähle was passendes aus.
+    description: Bitte wähle eine Kategorie aus.
     options:
     - Kurserstellung
-    - Fahrzeug Einstellungen
-    - Globale CP Einstellungen
+    - Fahrzeug-Einstellungen
+    - Globale CP-Einstellungen
     - weiteres später
     default: 0
   validations:
@@ -85,7 +85,7 @@ body:
   id: screenshots
   attributes:
     label: Screenshots
-    description: Ziehe deine Screenshots in das Textfeld, um diese hoch zu laden.
+    description: Ziehe deine Screenshots in das Textfeld, um diese hochzuladen.
     placeholder: Wenn du Screenshots hast, die helfen dein Frage zu beschreiben, füge
       sie hier ein.
   validations:

--- a/.github/ISSUE_TEMPLATE/QUESTION_EN.yml
+++ b/.github/ISSUE_TEMPLATE/QUESTION_EN.yml
@@ -10,8 +10,8 @@ body:
       Please make sure to read our [Wiki Page](https://github.com/Courseplay/Courseplay_FS25/wiki)
       before creating a new issue!
 
-      Our help pages from the game can also be found at [Courseplay.dev]!(https://courseplay.github.io/Courseplay_FS22.github.io/),
-      there you can check out many informations before asking a qustion!
+      You can also find our in-game help pages on the [Courseplay website](https://courseplay.github.io/CourseplayHelpFS25/),
+      which includes lots of useful information that may answer your question.
 
       '
 - type: dropdown

--- a/.github/ISSUE_TEMPLATE/REQUEST_DE.yml
+++ b/.github/ISSUE_TEMPLATE/REQUEST_DE.yml
@@ -7,15 +7,18 @@ body:
   attributes:
     value: 'Danke, dass du dir Zeit nimmst, diesen Report auszufüllen.
 
-      Lese dir bitte zuerst unsere [Wiki Seite](https://github.com/Courseplay/Courseplay_FS25/wiki)
+      Lies dir bitte zuerst unsere [Wiki-Seite](https://github.com/Courseplay/Courseplay_FS25/wiki)
       durch, bevor du ein neues Issue erstellst!
+
+      Unsere Hilfe aus dem Spiel gibt es auch auf der [CP-Website](https://courseplay.github.io/CourseplayHelpFS25/de/),
+      dort kannst du bereits vieles zu Courseplay erfahren!
 
       '
 - type: dropdown
   id: mod-version
   attributes:
     label: Version
-    description: Welche CP Version verwendest du?
+    description: Welche CP-Version verwendest du?
     options:
     - '0'
     - 8.0.0.0
@@ -68,7 +71,7 @@ body:
 - type: textarea
   id: how-to
   attributes:
-    label: Wie könntest du dir vorstellen, wie deine Idee in CP aussehen könnte.
+    label: Wie könnte deine Idee in Courseplay aussehen?
     description: Beschreibe bitte, wie es in CP passen könnte.
     placeholder: Beschreibe es so gut es geht.
   validations:
@@ -85,7 +88,7 @@ body:
   id: screenshots
   attributes:
     label: Screenshots
-    description: Ziehe deine Screenshots in das Textfeld, um diese hoch zu laden.
+    description: Ziehe deine Screenshots in das Textfeld, um diese hochzuladen.
     placeholder: Wenn du Screenshots hast, die helfen deine Idee besser zu verstehen,
       füge sie bitte hier ein.
   validations:

--- a/.github/ISSUE_TEMPLATE/REQUEST_EN.yml
+++ b/.github/ISSUE_TEMPLATE/REQUEST_EN.yml
@@ -10,6 +10,9 @@ body:
       Please make sure to read our [Wiki Page](https://github.com/Courseplay/Courseplay_FS25/wiki)
       before creating a new issue!
 
+      You can also find our in-game help pages on the [Courseplay website](https://courseplay.github.io/CourseplayHelpFS25/),
+      which includes lots of useful information.
+
       '
 - type: dropdown
   id: mod-version

--- a/README.md
+++ b/README.md
@@ -1,23 +1,26 @@
-# Courseplay Beta for Farming Simulator 2025
+# Courseplay Beta for Farming Simulator 25
 
-<!-- [![Modhub release](https://img.shields.io/badge/Modhub%20Release-Modification-blue.svg)](https://www.farming-simulator.com/mod.php?mod_id=248390title=fs2022)-->
-[![GitHub release (latest by date including pre-releases)](https://img.shields.io/github/v/release/Courseplay/Courseplay_FS25?include_prereleases&style=flat-square&label=Github+Release)](https://github.com/Courseplay/Courseplay_FS25/releases/latest)
-[![GitHub Pre-Releases (by Asset)](https://img.shields.io/github/downloads-pre/Courseplay/Courseplay_FS25/latest/FS25_Courseplay.zip?style=flat-square)](https://github.com/Courseplay/Courseplay_FS25/releases/latest/download/FS25_Courseplay.zip)
-[![GitHub issues](https://img.shields.io/github/issues/Courseplay/Courseplay_FS25?style=flat-square)](https://github.com/Courseplay/Courseplay_FS25/issues)
+[![ModHub Release](https://img.shields.io/badge/dynamic/xml?color=blue&style=flat-square&label=Modhub+Release&prefix=v&query=%2F%2Fdiv%5B%40class%3D'table-row'%5D%5Bdiv%5B%40class%3D'table-cell'%5D%2Fb%5Btext()%3D'Version'%5D%5D%2Fdiv%5B%40class%3D'table-cell'%5D%5B2%5D&url=https%3A%2F%2Fwww.farming-simulator.com%2Fmod.php%3Flang%3Dde%26country%3Dde%26mod_id%3D331515%26title%3Dfs2025)](https://www.farming-simulator.com/mod.php?mod_id=331515&title=fs2025)
+[![GitHub Release (latest by date including pre-releases)](https://img.shields.io/github/v/release/Courseplay/Courseplay_FS25?include_prereleases&style=flat-square&label=GitHub+Release)](https://github.com/Courseplay/Courseplay_FS25/releases/latest)
+[![GitHub Release Downloads (by Asset)](https://img.shields.io/github/downloads-pre/Courseplay/Courseplay_FS25/latest/FS25_Courseplay.zip?style=flat-square)](https://github.com/Courseplay/Courseplay_FS25/releases/latest/download/FS25_Courseplay.zip)
+[![GitHub Issues](https://img.shields.io/github/issues/Courseplay/Courseplay_FS25?style=flat-square)](https://github.com/Courseplay/Courseplay_FS25/issues)
 
 **[Download the latest developer version](https://github.com/Courseplay/Courseplay_FS25/releases/latest)** (the file FS25_Courseplay.zip).
 
-<!-- **[Courseplay Website](https://courseplay.github.io/Courseplay_FS25.github.io/)** -->
+**[Courseplay Website](https://courseplay.github.io/CourseplayHelpFS25/)**
 
 
-This (and later, the Giants modhub) is the **only official source for Courseplay**,
-if you see it anywhere else, it's a scam.
+This and the Giants ModHub is the **only official source for Courseplay**, if you see it anywhere else, it's a scam.
 
 ## Tutorials
 
 German Tutorial by Mario Hirschfeld: https://www.youtube.com/playlist?list=PL-UvOFIL55_jXAy6UkVJuLOD5DWKLuzIm
 
 English Tutorial by Argsy Gaming: https://www.youtube.com/playlist?list=PLFh-GZbaG02w9uLl_qroCi6uVI0LDXrD1
+
+Courseplay functions are also documented on our [website](https://courseplay.github.io/CourseplayHelpFS25/) and in the in-game Courseplay menu.
+
+<img width="1920" height="1200" alt="Courseplay Website" src="https://github.com/user-attachments/assets/52a82a7e-ca9d-40ae-9443-f60c7cbeebe4" />
 
 ## Developer version
 

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -29,7 +29,7 @@ Originally developed for earlier versions of the game, Courseplay has continuall
 It also integrates seamlessly with other mods like AutoDrive, making it ideal for managing large-scale farms.
 Despite improvements to the in-game AI over the years, Courseplay remains the gold standard for automation in Farming Simulator, thanks to its flexibility, reliability, and active development community.
 
-For a link to our latest release, Help page and GitHub page where you can find more information, help, and report issues please visit <a href="https://courseplay.dev/">Courseplay Website</a>
+For a link to our latest release, Help page and GitHub page where you can find more information, help, and report issues please visit <a href="https://courseplay.github.io/CourseplayHelpFS25/">Courseplay Website</a>
 or go directly to our <a href="https://github.com/Courseplay/Courseplay_FS25">GitHub page</a>.
 
 Many thanks to our translators and to our community for reporting bugs, giving us feedback and great ideas.
@@ -68,7 +68,7 @@ Mit Courseplay können Spieler komplexe Aufgaben automatisieren, wie zum Beispie
 Außerdem lässt sich Courseplay nahtlos mit anderen Mods wie AutoDrive integrieren, was es ideal für die Verwaltung großer Farmen macht.
 Trotz der Verbesserungen der In-Game-KI im Laufe der Jahre bleibt Courseplay dank seiner Flexibilität, Zuverlässigkeit und der aktiven Entwickler-Community der Goldstandard für Automatisierung im Farming Simulator.
 
-Ein Link zu der neuesten Version, der Hilfe Seite und Github, wo du mehr Informationen und Hilfe findest, sowie Probleme und Bugs melden kannst, findest du auf unserer <a href="https://courseplay.dev/">Courseplay Webseite</a>
+Ein Link zu der neuesten Version, der Hilfe Seite und Github, wo du mehr Informationen und Hilfe findest, sowie Probleme und Bugs melden kannst, findest du auf unserer <a href="https://courseplay.github.io/CourseplayHelpFS25/de">Courseplay Webseite</a>
 oder du gehst direkt auf unsere <a href="https://github.com/Courseplay/Courseplay_FS25">GitHub Webseite</a>.
 
 Vielen Dank an unsere Community für die zahlreichen Übersetzungen, Bug Reports, Feedback und Vorschläge zur Verbesserung.


### PR DESCRIPTION
- Updated README.md, modDesc.xml, and issue templates to include links to the Courseplay website
- Adjusted grammar and spelling in issue templates
- Added website screenshot to README.md
- Added ModHub release badge (shields.io) to README.md
- Preview of readme.md: https://github.com/Jan2903/Courseplay_FS25/tree/readme