### PR TITLE
fix: field detection

### DIFF
--- a/scripts/field/FieldBoundaryDetector.lua
+++ b/scripts/field/FieldBoundaryDetector.lua
@@ -58,7 +58,6 @@ end
 ---@return boolean true if still in progress, false when done
 function FieldBoundaryDetector:update(dt)
     -- when we use the custom field, we are done immediately
-    self.logger:info('status: %d', self.courseField.state)
     -- FieldCourseField:update() returns true until it's state is FieldCourseDetectionState.FINISHED. Problem
     -- is, it may never go to the FINISHED state, and then our indication of done is that the callback is called with
     -- success == true, therefore use the self.done to indicate it.


### PR DESCRIPTION
Trigger successful field detection also when the callback is called with success == true, not only when the state changes to FINISHED, as apparently, the Giants field detector may get stuck in the FieldCourseDetectionState.ISLAND_DETECTION state even when finished successfully.

#1020