### PR TITLE
fix: custom field numbers

### DIFF
--- a/scripts/field/CustomFieldManager.lua
+++ b/scripts/field/CustomFieldManager.lua
@@ -72,7 +72,9 @@ function CustomFieldManager:getNewFieldNumber()
         local name = entry:getName()
         if name:startsWith("CP-") then 
             local n = entry:getFieldNumber()
-            numbers[n] = true
+            if n then
+                numbers[n] = true
+            end
         end
     end
     local ix = 1


### PR DESCRIPTION
Nil check when collecting the existing automatically named custom field numbers.

#1041

Rename a custom field to CP-number-number and then try creating a new one.