### PR TITLE
Performance getNearestWaypoints

### DIFF
--- a/scripts/Course.lua
+++ b/scripts/Course.lua
@@ -1333,6 +1333,39 @@ function Course:getNearestWaypoints(node, startIx)
     local dClosest, dClosestRightDirection = math.huge, math.huge
     local ixClosest, ixClosestRightDirection = 1, 1
 
+    local nearestRange = 50
+    local p = self.waypoints[1]
+    local x, z = 0, 0
+    local d = math.huge
+    local waypointIDs = {}
+
+    for i = startIx or 1, #self.waypoints do
+        p = self.waypoints[i]
+        x, _, z = p:getPosition()
+        d = MathUtil.getPointPointDistance(x, z, nx, nz)
+        if d < nearestRange then
+            table.insert(waypointIDs, i)
+        end
+    end
+
+    if #waypointIDs > 9 then
+        for _, i in ipairs (waypointIDs) do
+            p = self.waypoints[i]
+            x, _, z = self:getWaypointPosition(i)
+            d = MathUtil.getPointPointDistance(x, z, nx, nz)
+            if d < dClosest then
+                dClosest = d
+                ixClosest = i
+            end
+            local deltaAngle = math.abs(CpMathUtil.getDeltaAngle(math.rad(p.angle), nodeAngle))
+            if d < dClosestRightDirection and deltaAngle < maxDeltaAngle then
+                dClosestRightDirection = d
+                ixClosestRightDirection = i
+            end
+        end
+        return ixClosest, dClosest, ixClosestRightDirection, dClosestRightDirection
+    end
+
     for i = startIx or 1, #self.waypoints do
         local p = self.waypoints[i]
         local x, _, z = self:getWaypointPosition(i)


### PR DESCRIPTION
This will speed up the function getNearestWaypoints by 5x.

Idea is to catch up the waypoints in a distance of 50m around the looking position with simple distance function instead of performing complex calculations on all waypoints. After that the complex calculations are performed on the catched waypoints to find the suitable nearest waypoint. In case less then 10 waypoints are found the existing approach is followed.

Possible further improvements:
- consider workwith instead of fixed 50m
- consider number of workers(multitools) on same course

Remark:
I will not invest more time on this, so leave it up to you: Take it, improve it or drop it.