### PR TITLE
Performance  PipeInFruitMap

### DIFF
--- a/scripts/ai/strategies/AIDriveStrategyCombineCourse.lua
+++ b/scripts/ai/strategies/AIDriveStrategyCombineCourse.lua
@@ -159,9 +159,12 @@ function AIDriveStrategyCombineCourse:setAllStaticParameters()
     --- if this is not nil, we have a pending rendezvous with our unloader
     ---@type CpTemporaryObject
     self.unloaderToRendezvous = CpTemporaryObject(nil)
-    local total, pipeInFruit = self.vehicle:getFieldWorkCourse():setPipeInFruitMap(self.pipeController:getPipeOffsetX(), self:getWorkWidth())
-    self:debug('Pipe in fruit map created, there are %d non-headland waypoints, of which at %d the pipe will be in the fruit',
-            total, pipeInFruit)
+    -- local total, pipeInFruit = self.vehicle:getFieldWorkCourse():setPipeInFruitMap(self.pipeController:getPipeOffsetX(), self:getWorkWidth())
+    -- self:debug('Pipe in fruit map created, there are %d non-headland waypoints, of which at %d the pipe will be in the fruit',
+            -- total, pipeInFruit)
+    self.pipeInFruitMapIndex = 0
+    self.pipeInFruitMapCountPerUpdate = 80
+    self.pipeInFruitMapFinished = false
     self.fillLevelFullPercentage = self.normalFillLevelFullPercentage
 end
 
@@ -222,6 +225,19 @@ function AIDriveStrategyCombineCourse:update(dt)
     AIDriveStrategyFieldWorkCourse.update(self, dt)
     self:updateChopperFillType()
     self:onDraw()
+
+    if not self.pipeInFruitMapFinished and self.course then
+        if self.pipeController and self.pipeController.getPipeOffsetX and self.pipeController:getPipeOffsetX() then
+            if self.getWorkWidth and self:getWorkWidth() then
+                if self.pipeInFruitMapIndex < self.course:getNumberOfWaypoints() + self.pipeInFruitMapCountPerUpdate then
+                    self.vehicle:getFieldWorkCourse():setPipeInFruitMapSegment(self.pipeController:getPipeOffsetX(), self:getWorkWidth(), self.pipeInFruitMapIndex, self.pipeInFruitMapCountPerUpdate)
+                    self.pipeInFruitMapIndex = self.pipeInFruitMapIndex + self.pipeInFruitMapCountPerUpdate
+                else
+                    self.pipeInFruitMapFinished = true
+                end
+            end
+        end
+    end
 end
 
 --- Hold the harvester for a period of periodMs milliseconds


### PR DESCRIPTION
This will replace the setPipeInFruitMap calculation in AIDriveStrategyCombineCourse with a segmented approach.

Background is a field course with > 500.000 waypoints. It takes > 4min on my PC to execute setPipeInFruitMap function before a harvester is starting to work and game is frozen during this time. Approach is to divide the calculation in small pieces to calculate the PipeInFruitMap. Currently 80 calculations are done in each update-frame, leading to complete the PipeInFruitMap after ~2min (Surprise!!!). During this time the isPipeInFruitAtWaypointNow function is used to determine if pipe might be in fruit area if isPipeInFruitAt value is not yet available. If isPipeInFruitAt value is available it will be used.

Possible further improvements:
- adjust the fixed 80 calculations per frame acording to the actual physics-FPS
- consider field harvest strategy CP_vehicle_courseGeneratorSetting_centerMode_...

Remark:
I will not invest more time on this, so leave it up to you: Take it, improve it or drop it.