### PR TITLE
Fix fuel save bypass in MotorController

### DIFF
--- a/scripts/ai/controllers/MotorController.lua
+++ b/scripts/ai/controllers/MotorController.lua
@@ -31,7 +31,6 @@ function MotorController:update()
             self.vehicle:raiseAIEvent('onAIFieldWorkerContinue', 'onAIImplementContinue')
         end
         self.timerSet = false
-        return
     end
     if self:isFuelSaveDisabled() or self.driveStrategy:getMaxSpeed() >
         self.speedThreshold then

--- a/scripts/ai/controllers/MotorController.lua
+++ b/scripts/ai/controllers/MotorController.lua
@@ -25,15 +25,8 @@ function MotorController:update()
     if not self.isValid then
         return
     end
-    if not self.settings.fuelSave:getValue() then
-        if not self:getIsStarted() then
-            self:startMotor()
-            self.vehicle:raiseAIEvent('onAIFieldWorkerContinue', 'onAIImplementContinue')
-        end
-        self.timerSet = false
-    end
     if self:isFuelSaveDisabled() or self.driveStrategy:getMaxSpeed() >
-        self.speedThreshold then
+        self.speedThreshold or not self.settings.fuelSave:getValue() then
         if not self:getIsStarted() then
             self:startMotor()
             self.vehicle:raiseAIEvent("onAIFieldWorkerContinue", "onAIImplementContinue")
@@ -84,7 +77,7 @@ function MotorController:getDriveData()
     end
     if g_Courseplay.globalSettings.waitForRefueling:getValue() and
         self:isFuelLow(self.fuelThresholdSetting:getValue()) then
-			
+
         maxSpeed = 0
     end
 


### PR DESCRIPTION
MotorController:update() was returning prematurely when Fuel Save was disabled, bypassing all additional MotorController logic.

Proposed fix for #1195