### PR TITLE
Allow disabling the seeder unit of cultivators with a seeder configuration (#989)

### DIFF
--- a/scripts/ai/controllers/SowingMachineController.lua
+++ b/scripts/ai/controllers/SowingMachineController.lua
@@ -10,19 +10,19 @@ end
 
 function SowingMachineController:update()
 	if not self.settings.optionalSowingMachineEnabled:getIsDisabled() then
-		if self.settings.optionalSowingMachineEnabled:getValue() then 
+		if self.settings.optionalSowingMachineEnabled:getValue() then
 			--- Makes sure the sowing machine get's turned on
 			if not self.implement:getIsTurnedOn() then
 				self.implement:setIsTurnedOn(true)
 			end
-		else 
+		else
 			--- Makes sure the sowing machine is turned off if not needed.
 			if self.implement:getIsTurnedOn() then
 				self.implement:setIsTurnedOn(false)
 			end
 		end
 	end
-	if self.sowingMachineSpec.showWrongFruitForMissionWarning then 
+	if self.sowingMachineSpec.showWrongFruitForMissionWarning then
 		self:debug("Wrong fruit type for mission selected!")
 		self.vehicle:stopCurrentAIJob(AIMessageErrorWrongMissionFruitType.new())
 	end
@@ -41,13 +41,48 @@ function SowingMachineController:onFinished()
     self.implement:setIsTurnedOn(false)
 end
 
+--- While Courseplay is driving and sowing was disabled by the user, the machine stays turned off.
+--- Without this override, TurnOnVehicle:getCanAIImplementContinueWork() fails for machines that
+--- require turning on but are turned off, so the driver would lower the implement and then just
+--- stand still, waiting forever (#989).
+local function getAIRequiresTurnOn(implement, superFunc, ...)
+	--- Only for cultivators with a seeder unit configuration, like the Horsch Finer 6 SL.
+	--- The structural check must not go through the setting's getIsDisabled() here, as that
+	--- calls isOptionalSowingMachineSettingVisible(), which in turn calls getAIRequiresTurnOn(),
+	--- resulting in an infinite recursion.
+	if implement.spec_sowingMachine ~= nil and
+			SpecializationUtil.hasSpecialization(Cultivator, implement.specializations) then
+		local rootVehicle = implement.rootVehicle
+		if rootVehicle ~= nil and rootVehicle.getIsCpActive and rootVehicle:getIsCpActive() then
+			local setting = rootVehicle:getCpSettings().optionalSowingMachineEnabled
+			if not setting:getValue() then
+				return false
+			end
+		end
+	end
+	return superFunc(implement, ...)
+end
+TurnOnVehicle.getAIRequiresTurnOn = Utils.overwrittenFunction(
+	TurnOnVehicle.getAIRequiresTurnOn, getAIRequiresTurnOn)
+
 -------------------------
 --- Refill handling
 -------------------------
 
 function SowingMachineController:needsRefilling()
+	if not self.settings.optionalSowingMachineEnabled:getIsDisabled() and
+			not self.settings.optionalSowingMachineEnabled:getValue() then
+		--- Sowing was disabled by the user, so no seeds are needed (#989).
+		return false
+	end
+	if self.implement:getFillUnitCapacity(self.sowingMachineSpec.fillUnitIndex) == 0 then
+		--- Sowing machines without a real seed tank (capacity 0), like the seeder unit
+		--- of the Horsch Finer 6 SL, don't consume seeds (see getSowingMachineCanConsume)
+		--- and therefore never need refilling (#989).
+		return false
+	end
 	if not g_currentMission.missionInfo.helperBuySeeds then
-		if self.implement:getFillUnitFillLevel(self.sowingMachineSpec.fillUnitIndex) <= 0 then 
+		if self.implement:getFillUnitFillLevel(self.sowingMachineSpec.fillUnitIndex) <= 0 then
 			return ImplementController.needsRefilling(self)
 		end
 	end

--- a/scripts/specializations/CpVehicleSettings.lua
+++ b/scripts/specializations/CpVehicleSettings.lua
@@ -358,12 +358,21 @@ end
 
 function CpVehicleSettings:isOptionalSowingMachineSettingVisible()
     local vehicles, found = AIUtil.getAllChildVehiclesWithSpecialization(self, SowingMachine)
-    return found and not vehicles[1]:getAIRequiresTurnOn()
+    if not found then
+        return false
+    end
+    if not vehicles[1]:getAIRequiresTurnOn() then
+        --- Passive sowing machines, for example a roller with a seeder configuration.
+        return true
+    end
+    --- Cultivators with a seeder unit configuration, like the Horsch Finer 6 SL,
+    --- are primarily cultivators, so sowing is optional for them as well, even
+    --- though their seeder unit needs to be turned on (#989).
+    return SpecializationUtil.hasSpecialization(Cultivator, vehicles[1].specializations)
 end
 
 function CpVehicleSettings:isOptionalSowingMachineSettingDisabled()
-    local vehicles, found = AIUtil.getAllChildVehiclesWithSpecialization(self, SowingMachine)
-    return not found or vehicles[1]:getAIRequiresTurnOn()
+    return not CpVehicleSettings.isOptionalSowingMachineSettingVisible(self)
 end
 
 


### PR DESCRIPTION
## Problem

Fixes #989.

The Horsch Finer 6 SL, Väderstad TopDown 600 and Dalbo Powerchain 800 gained a seeder unit configuration (vehicle type `cultivatingSowingMachine`) with game patch 1.8. Their sowing machine spec has `needsActivation="true"`, so `getAIRequiresTurnOn()` returns `true` and Courseplay hides the optional sowing setting for them. As a result the seeder unit is always turned on by the base game AI and cannot be disabled, even when the user only wants to cultivate.

## Changes

1. **`CpVehicleSettings`**: the optional sowing setting (`optionalSowingMachineEnabled`) is now also visible for implements that have both the `SowingMachine` and the `Cultivator` specialization, not only for passive sowing machines that don't require turning on. `isOptionalSowingMachineSettingDisabled()` mirrors the visibility check.

2. **`SowingMachineController`**: while a CP job is running and sowing is disabled by the user, an override of `TurnOnVehicle.getAIRequiresTurnOn()` returns `false` for these implements. Without this, `TurnOnVehicle:getCanAIImplementContinueWork()` fails for machines that require turning on but are turned off, so the driver lowers the implement and then stands still forever, waiting in `WAITING_FOR_LOWER`. 

   ⚠️ The override intentionally checks the specializations directly instead of using the setting's `getIsDisabled()`: that would call `isOptionalSowingMachineSettingVisible()`, which itself calls `getAIRequiresTurnOn()`, resulting in an infinite recursion (stack overflow every update loop).

3. **`SowingMachineController:needsRefilling()`**: no seeds are requested when sowing is disabled, or when the seed fill unit has capacity 0. The Finer 6 SL seeder unit has no real seed tank (`capacity="0"`, which per `SowingMachine:getSowingMachineCanConsume()` means it can always consume) — CP treated it as permanently empty and kept waiting for a refill that can never happen ("tank is empty" stop when sowing was enabled).

## Behavior

- Setting "Sowing option" appears in the vehicle settings (seeder section) for cultivators with a seeder unit configuration.
- Default is off (consistent with the existing optional sowing semantics), so the driver cultivates only; enabling it makes the driver seed as before.
- Normal seed drills are unaffected: without the `Cultivator` specialization the setting stays hidden/disabled and `getAIRequiresTurnOn()` falls through to the original implementation.

## Testing

Tested in SP on game version 1.10 with the Horsch Finer 6 SL (seeder unit configuration):
- Sowing option **off**: driver drives the course and only cultivates, seeder stays off, no refill request.
- Sowing option **on**: driver seeds, no more bogus "tank is empty" stop (capacity-0 tank).
- Manual driving and giants helper unaffected (override only active while a CP job is running).