### PR TITLE
Account for articulated harvester components when moving out of the way

### DIFF
--- a/scripts/ai/strategies/AIDriveStrategyUnloadCombine.lua
+++ b/scripts/ai/strategies/AIDriveStrategyUnloadCombine.lua
@@ -2176,15 +2176,12 @@ function AIDriveStrategyUnloadCombine:onBlockingVehicle(blockingVehicle, isBack)
             -- the tractor's) as when we reversing, it is easier when the trailer remains on the same side of the combine
             local dx, _, _ = localToLocal(referenceObject.rootNode, blockingVehicle:getAIDirectionNode(), 0, 0, 0)
             -- articulated harvesters can stand bent, with the rear part sticking out sideways from
-            -- the direction node - make sure the offset also clears the widest component, not just
-            -- the work width around the front part
-            local maxComponentOffset = 0
-            for _, component in pairs(blockingVehicle.components) do
-                local cdx, _, _ = localToLocal(component.node, blockingVehicle:getAIDirectionNode(), 0, 0, 0)
-                maxComponentOffset = math.max(maxComponentOffset, math.abs(cdx) + blockingVehicle.size.width / 2)
-            end
+            -- the direction node - make sure the offset also clears the widest part of the vehicle
+            -- in its current, possibly bent state, not just the work width around the front part
+            local _, _, dLeft, dRight = VehicleSizeScanner():scan(blockingVehicle, blockingVehicle:getAIDirectionNode())
+            local halfWidth = math.max(dLeft, -dRight)
             local xOffset = self.vehicle.size.width / 2 +
-                    math.max(blockingVehicle:getCpDriveStrategy():getWorkWidth() / 2, maxComponentOffset) + 2
+                    math.max(blockingVehicle:getCpDriveStrategy():getWorkWidth() / 2, halfWidth) + 2
             xOffset = dx > 0 and xOffset or -xOffset
             self:setNewState(self.states.MOVING_AWAY_FROM_OTHER_VEHICLE)
             self.state.properties.vehicle = blockingVehicle

--- a/scripts/ai/strategies/AIDriveStrategyUnloadCombine.lua
+++ b/scripts/ai/strategies/AIDriveStrategyUnloadCombine.lua
@@ -2175,7 +2175,16 @@ function AIDriveStrategyUnloadCombine:onBlockingVehicle(blockingVehicle, isBack)
             -- with an offset from the combine that makes sure we are clear. Use the trailer's root node (and not
             -- the tractor's) as when we reversing, it is easier when the trailer remains on the same side of the combine
             local dx, _, _ = localToLocal(referenceObject.rootNode, blockingVehicle:getAIDirectionNode(), 0, 0, 0)
-            local xOffset = self.vehicle.size.width / 2 + blockingVehicle:getCpDriveStrategy():getWorkWidth() / 2 + 2
+            -- articulated harvesters can stand bent, with the rear part sticking out sideways from
+            -- the direction node - make sure the offset also clears the widest component, not just
+            -- the work width around the front part
+            local maxComponentOffset = 0
+            for _, component in pairs(blockingVehicle.components) do
+                local cdx, _, _ = localToLocal(component.node, blockingVehicle:getAIDirectionNode(), 0, 0, 0)
+                maxComponentOffset = math.max(maxComponentOffset, math.abs(cdx) + blockingVehicle.size.width / 2)
+            end
+            local xOffset = self.vehicle.size.width / 2 +
+                    math.max(blockingVehicle:getCpDriveStrategy():getWorkWidth() / 2, maxComponentOffset) + 2
             xOffset = dx > 0 and xOffset or -xOffset
             self:setNewState(self.states.MOVING_AWAY_FROM_OTHER_VEHICLE)
             self.state.properties.vehicle = blockingVehicle


### PR DESCRIPTION
## Problem

When the unloader moves away from a blocking CP combine (`AIDriveStrategyUnloadCombine:onBlockingVehicle`), the parallel course offset is computed as `own width/2 + work width/2 + 2` around the combine's AI direction node. Articulated harvesters (e.g. the spinach harvester) can stand bent, with the rear component sticking out sideways well beyond that offset - the unloader then keeps touching the rear part and never gets past it.

## Solution

Scan the actual, current extents of the blocking vehicle with the existing `VehicleSizeScanner` (relative to its AI direction node) and use the larger of the scanned half width and the half work width for the offset. For rigid vehicles the scanned half width stays at (or below) the work-width-based value, so behavior there is unchanged. The scan runs once per blocking event, the same pattern `PathfinderUtil.VehicleData` uses at pathfinder start.

## Testing

Reproduced with a tractor + trailer blocked by a bent articulated spinach harvester; with the wider offset the unloader clears the rear component. (Originally verified with a component-position-based approximation; updated to `VehicleSizeScanner` per review - in-game re-test of the scanner version pending, will report here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
