### PR TITLE
Allow opening the course generator while AutoDrive is driving to the field

### DIFF
--- a/scripts/gui/pages/CpCourseGeneratorFrame.lua
+++ b/scripts/gui/pages/CpCourseGeneratorFrame.lua
@@ -1691,7 +1691,15 @@ function CpCourseGeneratorFrame:setAIVehicle(vehicle)
 	local hotspot = vehicle:getMapHotspot()
 	self:setMapSelectionItem(hotspot)
 	self.ingameMap:panToHotspot(hotspot)
-	if not vehicle:getIsAIActive() then 
+	-- AutoDrive reports getIsAIActive() == true while it drives the vehicle to its
+	-- target (Specialization.lua:getIsAIActive), even though no real AI/CP job is
+	-- running yet. Without this exception the course generator silently refuses to
+	-- open while AutoDrive is en route, so a course could never be prepared in advance.
+	local isOnlyAutoDriveDriving = vehicle.ad and vehicle.ad.stateModule and vehicle.ad.stateModule:isActive()
+	if isOnlyAutoDriveDriving then
+		CpUtil.info("[CP ad-gate-fix] %s: AutoDrive active, getIsAIActive=%s, opening course creator anyway", vehicle:getName(), tostring(vehicle:getIsAIActive()))
+	end
+	if not vehicle:getIsAIActive() or isOnlyAutoDriveDriving then
 		self:onCreateJob()
 	end
 end


### PR DESCRIPTION
## Problem

While AutoDrive is driving a vehicle to the field (e.g. via `driveTo`/`driveToVehicle`), the Courseplay course generator refuses to open for that vehicle at all - there's no way to prepare a course in advance while AutoDrive is still en route.

## Root cause

`AutoDrive:getIsAIActive()` (FS25_AutoDrive `scripts/Specialization.lua`) overrides the base-game function to return `true` whenever AutoDrive's own `stateModule:isActive()` is true - i.e. simply "AutoDrive is driving", not "a real AI/CP job is running".

`CpCourseGeneratorFrame:setAIVehicle()` uses that same `getIsAIActive()` to decide whether to open the job-creation UI (mirroring the vanilla "vehicle already has a job, show cancel instead of create" behavior). So AutoDrive driving alone silently blocks course creation, even though no CP job exists yet.

## Fix

`setAIVehicle` now also opens the creator when the only reason `getIsAIActive()` is true is AutoDrive's own `stateModule:isActive()`. This is safe because AutoDrive clears `stateModule` to `false` in `stopAutoDrive()` *before* handing control to a real job - so a vehicle with an actually-running CP/base-game job is still correctly blocked from re-creating one.

## Testing

Verified in-game repeatedly across several vehicles (AgroStar 8.31, Axial-Flow 7160 x2, FORTERRA HSX 120, T215 Active, Puma 260 CVXDrive x2): course generator opens reliably while AutoDrive is driving to the field, no misbehavior observed (no accidental course creation while a real job is running).

🤖 Generated with [Claude Code](https://claude.com/claude-code)