### PR TITLE
fix: don't build the vehicle HUD on a dedicated server

### DIFF
--- a/scripts/specializations/CpHud.lua
+++ b/scripts/specializations/CpHud.lua
@@ -284,6 +284,10 @@ function CpHud:getCpStatus()
 end
 
 function CpHud:onPostLoad(savegame)
+    --- The hud is only ever drawn or interacted with on a client.
+    if not self.isClient then
+        return
+    end
     local spec = self.spec_cpHud
     spec.hud = CpBaseHud(self)
 end


### PR DESCRIPTION
## What this changes

`CpHud:onPostLoad` builds a `CpBaseHud` for every CP-capable vehicle. It's registered as a plain event listener (`CpHud.lua:43`), so it runs on a dedicated server too — where the HUD is never drawn.

```lua
function CpHud:onPostLoad(savegame)
    local spec = self.spec_cpHud
    spec.hud = CpBaseHud(self)     -- :288, no isClient guard
end
```

`CpBaseHud:init` (`scripts/gui/hud/CpBaseHud.lua:71-309`) is pure client work: `g_gameSettings:getValue("uiScale")` (`:74`), `getNormalizedScreenValues` (`:82`, `:84`), `g_screenAspectRatio` (`:88`), **11 `Overlay.new` allocations** (`:106`, `:139`, `:157`, `:185`, `:196`, `:209`, `:226`, `:241`, `:259`, `:275`, `:292`), plus five full HUD page trees via `addHudPage`, each with their own overlays and button overlays.

The same file already guards this correctly 180 lines further up:

```lua
function CpHud:onRegisterActionEvents(...)
    if self.isClient then     -- :104
```

This PR applies the same guard to `onPostLoad`.

## Why it's safe

No server-side path reads `spec.hud`. I checked every consumer:

| Consumer | Why it can't hit a nil hud on a dedi |
|---|---|
| `onEnterVehicle:304` | gated at `:300` by `self == CpUtil.getCurrentVehicle()`, which returns `nil` when `g_localPlayer` is nil (`CpUtil.lua:487-491`) |
| `onDrawUIInfo:359` | gated at `:354` by the same call; also a draw path |
| `actionEventMouse:140/145/153` | input action — action events are only registered under `if self.isClient` (`:104`) |
| `getIsMouseOverCpHud:100` | only reached from `actionEventCameraZoomInOut:317`, an input action |
| `enterVehicleRaycastClickToSwitch:90` | mouse raycast |
| `closeCpHud:172` | only called from `CpBaseHud.lua:206`, i.e. from a HUD that exists |
| `getCpHud:178` | only caller is `Courseplay.lua:225`, already nil-guarded (`vehicle and vehicle.getCpHud and vehicle:getCpHud()` → `if hud then`) |
| `onUpdate:339-350` | the `isServer` branch touches `spec.status` and `spec.hudSettings` only — never `spec.hud` |
| `resetCpHud:158-167` | does not touch `spec.hud` (the line that would is commented out at `:166`) |

`luac -p` passes.

## Honesty about verification

This is **statically verified, not measured in-game**. What I have counted is the allocation sites (11 overlays + 5 page trees per vehicle) and proven that the construction runs headless and that nothing headless consumes it. What I have **not** done is measure the actual memory or load-time delta on a server — so I'm deliberately not putting a number on the benefit, and I'm not claiming this fixes a crash. It doesn't; CP demonstrably runs fine on dedicated servers today.

I run a dedicated server with a large mod set and I'm happy to measure a before/after load time if that's useful for judging whether this is worth taking.

## Side note (not touched here)

`CpHud:cpInit` (`:412-414`) is a second, also unguarded HUD construction site, and it appears to be dead: repo-wide, `cpInit` only shows up at its registration (`:59`) and its definition (`:412`) — no callers. Left alone to keep this diff to the one guard, but worth a look if you're cleaning up.
