### PR TITLE
Improve coordination between combine and unloader at end of row

### DIFF
--- a/scripts/ai/strategies/AIDriveStrategyCombineCourse.lua
+++ b/scripts/ai/strategies/AIDriveStrategyCombineCourse.lua
@@ -268,7 +268,11 @@ function AIDriveStrategyCombineCourse:getDriveData(dt, vX, vY, vZ)
                 self:changeToUnloadOnField()
             end
         elseif self:shouldWaitAtEndOfRow() then
-            self:startWaitingForUnloadBeforeNextRow()
+            if self:isSideBySideUnloading() then
+                self:startUnloadingAtRowEnd()
+            else
+                self:startWaitingForUnloadBeforeNextRow()
+            end
         end
 
         if not self.pipeController:isInAllowedState() then
@@ -682,6 +686,31 @@ function AIDriveStrategyCombineCourse:startWaitingForUnloadBeforeNextRow()
     self:stopForUnload(self.states.WAITING_FOR_UNLOAD_BEFORE_STARTING_NEXT_ROW, true)
 end
 
+--- Discharging into a CP unloader or trailer under the pipe.
+---@return boolean
+function AIDriveStrategyCombineCourse:isUnloadingIntoUnloader()
+    if not self:isDischarging() or self:hasAutoAimPipe() then
+        return false
+    end
+    return self.pipeController:isFillableTrailerUnderPipe() or self.unloader:get() ~= nil
+end
+
+--- Side-by-side unload close to the end of the row: already discharging, so skip stopForUnload and keep the header down.
+function AIDriveStrategyCombineCourse:startUnloadingAtRowEnd()
+    self:debug('Unloading into unloader at end of row, waiting for unload to finish')
+    self:cancelRendezvous()
+    self.state = self.states.UNLOADING_ON_FIELD
+    self.unloadState = self.states.UNLOADING_BEFORE_STARTING_NEXT_ROW
+end
+
+--- Side-by-side unload with stopForUnload off: discharging into a trailer/unloader while still driving.
+---@return boolean
+function AIDriveStrategyCombineCourse:isSideBySideUnloading()
+    return not self.settings.stopForUnload:getValue()
+            and not self:alwaysNeedsUnloader()
+            and self:isUnloadingIntoUnloader()
+end
+
 --- The unloader may call this repeatedly to confirm that the rendezvous still stands, making sure the
 --- combine won't give up and keeps waiting
 function AIDriveStrategyCombineCourse:reconfirmRendezvous()
@@ -851,6 +880,10 @@ function AIDriveStrategyCombineCourse:shouldWaitAtEndOfRow()
             nextRowStartIx > self.unloaderRendezvousWaypointIx then
         self:debug('shouldWaitAtEndOfRow: Closer than %.1f m to a turn and rendezvous waypoint %d is before the turn, waiting for the unloader here',
                 AIDriveStrategyCombineCourse.safeUnloadDistanceBeforeEndOfRow, self.unloaderRendezvousWaypointIx)
+        return true
+    end
+    if closeToTurn and self:isSideBySideUnloading() then
+        self:debug('shouldWaitAtEndOfRow: close to turn while discharging side-by-side, waiting for unload to finish')
         return true
     end
 end
@@ -1368,6 +1401,19 @@ end
 function AIDriveStrategyCombineCourse:isWaitingForUnloadAfterPulledBack()
     return self.state == self.states.UNLOADING_ON_FIELD and
             self.unloadState == self.states.WAITING_FOR_UNLOAD_AFTER_PULLED_BACK
+end
+
+---@return boolean true when waiting to unload at the end of a row before starting the next one
+function AIDriveStrategyCombineCourse:isWaitingForUnloadBeforeNextRow()
+    return self.state == self.states.UNLOADING_ON_FIELD and
+            (self.unloadState == self.states.WAITING_FOR_UNLOAD_BEFORE_STARTING_NEXT_ROW or
+                    self.unloadState == self.states.UNLOADING_BEFORE_STARTING_NEXT_ROW)
+end
+
+---@return boolean true when unload is done and the combine waits for the unloader to clear before resuming
+function AIDriveStrategyCombineCourse:isWaitingForUnloaderToLeave()
+    return self.state == self.states.UNLOADING_ON_FIELD and
+            self.unloadState == self.states.WAITING_FOR_UNLOADER_TO_LEAVE
 end
 
 ---@return boolean the combine is about to turn
@@ -2045,7 +2091,9 @@ function AIDriveStrategyCombineCourse:willWaitForUnloadToFinish()
             ((self.settings.stopForUnload:getValue() and self.unloadState == self.states.WAITING_FOR_UNLOAD_ON_FIELD) or
                     self.unloadState == self.states.WAITING_FOR_UNLOAD_IN_POCKET or
                     self.unloadState == self.states.WAITING_FOR_UNLOAD_AFTER_PULLED_BACK or
-                    self.unloadState == self.states.WAITING_FOR_UNLOAD_AFTER_FIELDWORK_ENDED)
+                    self.unloadState == self.states.WAITING_FOR_UNLOAD_AFTER_FIELDWORK_ENDED or
+                    self.unloadState == self.states.WAITING_FOR_UNLOAD_BEFORE_STARTING_NEXT_ROW or
+                    self.unloadState == self.states.UNLOADING_BEFORE_STARTING_NEXT_ROW)
 end
 
 --- Try to not hit our Unloader after Pocket.

--- a/scripts/ai/strategies/AIDriveStrategyUnloadCombine.lua
+++ b/scripts/ai/strategies/AIDriveStrategyUnloadCombine.lua
@@ -473,10 +473,9 @@ function AIDriveStrategyUnloadCombine:getDriveData(dt, vX, vY, vZ)
 
     elseif self.state == self.states.MOVING_BACK_WITH_TRAILER_FULL then
         self:setMaxSpeed(self.settings.reverseSpeed:getValue())
-        -- drive back to have some room for the pathfinder
-        local _, dx, dz = self:getDistanceFromCombine(self.state.properties.vehicle)
-        -- drive back more if we are close to the harvester
-        if dz > ((math.abs(dx) < self.turningRadius) and 0 or -3) then
+        -- drive back until the combine is behind us before going to unload the trailer
+        local _, _, dz = self:getDistanceFromCombine(self.state.properties.vehicle)
+        if dz > 0 then
             self:startUnloadingTrailers()
         end
 
@@ -1960,6 +1959,10 @@ function AIDriveStrategyUnloadCombine:unloadStoppedCombine()
     end
     local gx, gz
     local combineDriver = self.combineToUnload:getCpDriveStrategy()
+    if combineDriver:isWaitingForUnloaderToLeave() then
+        self:backAwayWhenCombineWaitingToLeave(combineDriver)
+        return
+    end
     if combineDriver:isUnloadFinished() then
         if combineDriver:isWaitingForUnloadAfterCourseEnded() then
             if combineDriver:getFillLevelPercentage() < 0.1 then
@@ -2004,6 +2007,11 @@ function AIDriveStrategyUnloadCombine:unloadMovingCombine()
 
     local combineStrategy = self.combineToUnload:getCpDriveStrategy()
     local gx, gz = self:driveBesideCombine()
+
+    if combineStrategy:isWaitingForUnloaderToLeave() then
+        self:backAwayWhenCombineWaitingToLeave(combineStrategy)
+        return
+    end
 
     --when the combine is empty, stop and wait for next combine (unless this can't work without an unloader nearby)
     if combineStrategy:getFillLevelPercentage() <= 0.1 and not combineStrategy:alwaysNeedsUnloader() then
@@ -2076,8 +2084,9 @@ function AIDriveStrategyUnloadCombine:onUnloadingMovingCombineFinished(combineSt
     elseif combineStrategy:isTurningOnHeadland() then
         self:debug('combine empty and turning on headland, moving back')
         self:startMakingRoomForCombineTurningOnHeadland(self.combineToUnload)
-    elseif combineStrategy:isTurning() or combineStrategy:isAboutToTurn() then
-        self:debug('combine empty and moving forward but we are too close to the end of the row or combine is turning, moving back')
+    elseif combineStrategy:isWaitingForUnloaderToLeave() or combineStrategy:isWaitingForUnloadBeforeNextRow() or
+            combineStrategy:isTurning() or combineStrategy:isAboutToTurn() then
+        self:debug('combine empty at end of row or turning, moving back to make room')
         self:startMovingBackFromCombine(self.states.MOVING_BACK, self.combineToUnload, true)
         return
     elseif self:getAllTrailersFull(self.settings.fullThreshold:getValue()) then
@@ -2097,6 +2106,25 @@ end
 ------------------------------------------------------------------------------------------------------------------------
 -- Start moving back from empty combine
 ------------------------------------------------------------------------------------------------------------------------
+function AIDriveStrategyUnloadCombine:isBackingAwayFromCombine()
+    return self.state == self.states.MOVING_BACK
+            or self.state == self.states.MOVING_BACK_WITH_TRAILER_FULL
+            or self.state == self.states.MOVING_BACK_FOR_HEADLAND_TURN
+            or self.state == self.states.MOVING_BACK_BEFORE_PATHFINDING
+end
+
+--- The combine entered WAITING_FOR_UNLOADER_TO_LEAVE; back away if we have not already.
+---@param combineStrategy AIDriveStrategyCombineCourse
+function AIDriveStrategyUnloadCombine:backAwayWhenCombineWaitingToLeave(combineStrategy)
+    if self:isBackingAwayFromCombine() then
+        return
+    end
+    if combineStrategy:isWaitingForUnloaderToLeave() then
+        self:debug('Combine waiting for unloader to leave, moving back')
+        self:startMovingBackFromCombine(self.states.MOVING_BACK, self.combineToUnload, true)
+    end
+end
+
 function AIDriveStrategyUnloadCombine:startMovingBackFromCombine(newState, combine, holdCombineWhileMovingBack)
     if self.unloadTargetType == self.UNLOAD_TYPES.SILO_LOADER then
         --- Finished unloading of silo unloader. Moving back is not needed.


### PR DESCRIPTION
Hi, new to this project, submitting a fix for an issue I've experienced with unloader/combine coordination.

When a combine is unloading into a trailer while driving, it stops at the end of the row thanks to a turning+unloading check at the end of `getDriveData()`. The issue is that this doesn't shift the combine into a different state and just holds it in place, so when the unloading is finished, the combine tries to resume the turn immediately without giving the unloader time to move out of the way. In certain fields this causes problems because the tractor might be ahead of the combine.

This PR fixes that issue by adding a unloading check in `shouldWaitAtEndOfRow()` which shifts the combine into the `UNLOADING_ON_FIELD` + `UNLOADING_BEFORE_STARTING_NEXT_ROW` state which waits for the unload to finish and then kicks off the unloader backup logic before continuing, this way the combine waits for the unloader to give it space.

It also updates the unloader logic to better detect when the combine is waiting for the unlaoder to leave and trigger a back off.