### PR TITLE
Add a button to set the job positions to the vehicle position

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -404,6 +404,10 @@ Changelog 8.1.0.3
 		<actionBinding action="CP_GENERATE_COURSE">
 			<binding device="KB_MOUSE_DEFAULT" input="KEY_lctrl KEY_g" />
 		</actionBinding>
+		<!--- Only used in the course generator menu while creating a job, where KEY_v is free. -->
+		<actionBinding action="CP_SET_POSITIONS_TO_VEHICLE">
+			<binding device="KB_MOUSE_DEFAULT" input="KEY_v" />
+		</actionBinding>
 
 		<actionBinding action="CP_CHANGE_SELECTED_JOB">
 			<binding device="" input="" />
@@ -451,6 +455,7 @@ Changelog 8.1.0.3
 		<action name="CP_START_STOP_AT_NEAREST_WAYPOINT"/>
 		<action name="CP_START_STOP_AT_LAST_WAYPOINT"/>
 		<action name="CP_GENERATE_COURSE" />
+		<action name="CP_SET_POSITIONS_TO_VEHICLE" />
 
 		<action name="CP_CHANGE_SELECTED_JOB"/>
 		<action name="CP_CHANGE_STARTING_POINT"/>

--- a/scripts/gui/pages/CpCourseGeneratorFrame.lua
+++ b/scripts/gui/pages/CpCourseGeneratorFrame.lua
@@ -1153,7 +1153,7 @@ function CpCourseGeneratorFrame:getNumberOfItemsInSection(list, section)
 	end
 	if list == self.contextButtonList then 
 		self.contextActionMapping = {}
-		for index, action in pairs(self.contextActions) do 
+		for index, action in ipairs(self.contextActions) do 
 			if action.isActive and not action.actionOnly then 
 				table.insert(self.contextActionMapping, index)
 			end
@@ -1165,7 +1165,7 @@ function CpCourseGeneratorFrame:getNumberOfItemsInSection(list, section)
 	end
 	if list == self.contextButtonCustomFieldList then 
 		self.contextActionMapping = {}
-		for index, action in pairs(self.contextActions) do 
+		for index, action in ipairs(self.contextActions) do 
 			if action.isActive and not action.actionOnly then 
 				table.insert(self.contextActionMapping, index)
 			end

--- a/scripts/gui/pages/CpCourseGeneratorFrame.lua
+++ b/scripts/gui/pages/CpCourseGeneratorFrame.lua
@@ -35,14 +35,17 @@ CpCourseGeneratorFrame = {
 	CONTEXT_ACTIONS = {
 		ENTER_VEHICLE 	= 1,
 		CREATE_JOB		= 2,
-		START_JOB		= 3,
-		STOP_JOB		= 4,
-		GENERATE_COURSE = 5,
-		DELETE_CUSTOM_FIELD = 6,
-		RENAME_CUSTOM_FIELD = 7,
-		EDIT_CUSTOM_FIELD 	= 8,
-		DRAW_CUSTOM_FIELD 	= 9,
-		HOTSPOT_SELECT_ALL	= 10
+		--- These three show up in the create job button list in this order, which is also
+		--- the usual work flow: set the positions, generate the course, start the job.
+		SET_POSITIONS_TO_VEHICLE = 3,
+		GENERATE_COURSE = 4,
+		START_JOB		= 5,
+		STOP_JOB		= 6,
+		DELETE_CUSTOM_FIELD = 7,
+		RENAME_CUSTOM_FIELD = 8,
+		EDIT_CUSTOM_FIELD 	= 9,
+		DRAW_CUSTOM_FIELD 	= 10,
+		HOTSPOT_SELECT_ALL	= 11
 	},
 	AI_MODE_OVERVIEW = 1,
 	AI_MODE_CREATE = 2,
@@ -945,6 +948,63 @@ function CpCourseGeneratorFrame:getIsPicking()
 	return self.isPickingRotation or self.isPickingLocation
 end
 
+--- Sets the target position (the position the helper drives to first, with the vehicle's direction)
+--- and the field/silo position of the job currently being created to the vehicle's position, so
+--- these don't have to be picked on the map when standing on the field already.
+function CpCourseGeneratorFrame:setJobPositionsToVehiclePosition()
+	local vehicle = self.currentJobVehicle
+	if self.currentJob == nil or vehicle == nil or vehicle.rootNode == nil or self:getIsPicking() then
+		return
+	end
+	local x, _, z = getWorldTranslation(vehicle.rootNode)
+	local dirX, _, dirZ = localDirectionToWorld(vehicle.rootNode, 0, 0, 1)
+	local angle = MathUtil.getYRotationFromDirection(dirX, dirZ)
+	local changed = false
+	for _, element in ipairs(self.currentJobElements) do
+		local parameter = element.aiParameter
+		if parameter and parameter.is_a and parameter:is_a(CpAIParameterPosition) and parameter:getCanBeChanged() then
+			local positionType = parameter:getPositionType()
+			if positionType == CpAIParameterPositionAngle.POSITION_TYPES.DRIVE_TO then
+				parameter:setPosition(x, z)
+				if parameter.setAngle then
+					--- the target of the drive to task also has a direction, use the one the vehicle is facing
+					parameter:setAngle(angle)
+				end
+				changed = true
+			elseif positionType == CpAIParameterPositionAngle.POSITION_TYPES.FIELD_OR_SILO then
+				parameter:setPosition(x, z)
+				changed = true
+			end
+		end
+	end
+	if changed then
+		--- this also restarts the field boundary detection for the new field position
+		self:validateParameters()
+		self:updateParameterValueTexts()
+	end
+end
+
+--- Adds a button to the job parameter list, which sets the target and the field position
+--- to the vehicle's current position. It gets a group of its own so it is separated from
+--- the position rows above and isn't clicked by accident.
+function CpCourseGeneratorFrame:addSetPositionsToVehicleButton()
+	local titleElement = self.createTitleTemplate:clone(self.jobMenuLayout)
+	titleElement:setText(g_i18n:getText("CP_ai_page_positions_to_vehicle_title"))
+	--- Using the position parameter template, so the button looks and behaves exactly
+	--- like the position rows above it.
+	local element = self.createPositionTemplate:clone(self.jobMenuLayout)
+	FocusManager:loadElementFromCustomValues(element)
+	element:setText(g_i18n:getText("CP_ai_page_positions_to_vehicle"))
+	local invalidElement = element:getDescendantByName("invalid")
+	if invalidElement then
+		invalidElement:setVisible(false)
+	end
+	element.onClickCallback = function()
+		self:setJobPositionsToVehiclePosition()
+	end
+	return element
+end
+
 function CpCourseGeneratorFrame:validateParameters()
 	local isValid = true
 	local errorText = ""
@@ -1455,6 +1515,12 @@ function CpCourseGeneratorFrame:initializeContextActions()
 			callback = self.onCreateJob,
 			isActive = false
 		},
+		[self.CONTEXT_ACTIONS.SET_POSITIONS_TO_VEHICLE] = {
+			text = g_i18n:getText("CP_ai_page_positions_to_vehicle"),
+			action = InputAction.CP_SET_POSITIONS_TO_VEHICLE,
+			callback = self.setJobPositionsToVehiclePosition,
+			isActive = false
+		},
 		[self.CONTEXT_ACTIONS.START_JOB] = {
 			text = g_i18n:getText("button_startJob"),
 			action = InputAction.MENU_EXTRA_1,
@@ -1547,6 +1613,9 @@ function CpCourseGeneratorFrame:updateContextActions()
 		end
 	end
 	self.contextActions[self.CONTEXT_ACTIONS.CREATE_JOB].isActive = self.canCreateJob and self.mode ~= self.AI_MODE_CREATE
+	self.contextActions[self.CONTEXT_ACTIONS.SET_POSITIONS_TO_VEHICLE].isActive =
+		self.mode == self.AI_MODE_CREATE and self.currentJob ~= nil and
+		self.currentJobVehicle ~= nil and not self:getIsPicking()
 	self.contextActions[self.CONTEXT_ACTIONS.START_JOB].isActive = self:getCanStartJob()
 	self.contextActions[self.CONTEXT_ACTIONS.STOP_JOB].isActive = self:getCanCancelJob() and self.mode ~= self.AI_MODE_CREATE
 	self.contextActions[self.CONTEXT_ACTIONS.GENERATE_COURSE].isActive = self:getCanGenerateFieldWorkCourse()
@@ -1765,11 +1834,27 @@ function CpCourseGeneratorFrame:setActiveJobTypeSelection(jobTypeIndex)
 		end
 		self.currentJob:applyCurrentState(self.currentJobVehicle, g_currentMission, farmId, false)
 		self.currentJobElements = {}
+		--- The button setting the positions to the vehicle position goes right below the field/silo
+		--- position, or below the target position for jobs without a field position (silo loader).
+		local buttonAnchorPositionType = nil
+		for _, group in ipairs(self.currentJob:getGroupedParameters()) do
+			for _, item in ipairs(group:getParameters()) do
+				local positionType = item.getPositionType and item:getPositionType()
+				if positionType == CpAIParameterPositionAngle.POSITION_TYPES.FIELD_OR_SILO then
+					buttonAnchorPositionType = positionType
+				elseif positionType == CpAIParameterPositionAngle.POSITION_TYPES.DRIVE_TO and
+					buttonAnchorPositionType == nil then
+					buttonAnchorPositionType = positionType
+				end
+			end
+		end
+		local isButtonAdded = false
 		for _, group in ipairs(self.currentJob:getGroupedParameters()) do
 			local titleElement = self.createTitleTemplate:clone(self.jobMenuLayout)
 
 			titleElement:setText(group:getTitle())
 
+			local isButtonAnchorGroup = false
 			for _, item in ipairs(group:getParameters()) do
 				local element = nil
 				local parameterType = item:getType()
@@ -1797,7 +1882,15 @@ function CpCourseGeneratorFrame:setActiveJobTypeSelection(jobTypeIndex)
 					end
 					element:setDisabled(not item:getCanBeChanged())
 					table.insert(self.currentJobElements, element)
+					if buttonAnchorPositionType ~= nil and item.getPositionType and
+						item:getPositionType() == buttonAnchorPositionType then
+						isButtonAnchorGroup = true
+					end
 				end
+			end
+			if isButtonAnchorGroup and not isButtonAdded then
+				self:addSetPositionsToVehicleButton()
+				isButtonAdded = true
 			end
 		end
 		self:validateParameters()

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -108,6 +108,8 @@
     <text name="CP_job_bunkerSilo" text="CP: Siloarbeit"/>
     <text name="CP_job_siloLoader" text="CP: Silo laden"/>
     <text name="CP_ai_page_generate_course" text="CP: Feldkurs generieren"/>
+    <text name="CP_ai_page_positions_to_vehicle" text="Ziel &amp; Feld auf Fahrzeug"/>
+    <text name="CP_ai_page_positions_to_vehicle_title" text="Positionen setzen"/>
     <text name="CP_ai_page_open_course_generator" text="CP: Kursgenerator öffnen/schließen"/>
     <!---->
     <!--AI error messages-->
@@ -1076,6 +1078,7 @@ Das Kreuz sollte jetzt, wie im Bild dargestellt, gelb sein.
     <text name="input_CP_START_STOP_AT_NEAREST_WAYPOINT" text="CP: CP-Helfer starten/stoppen (am nächsten Wegpunkt)"/>
     <text name="input_CP_START_STOP_AT_LAST_WAYPOINT" text="CP: CP-Helfer starten/stoppen (am letzten Wegpunkt)"/>
     <text name="input_CP_GENERATE_COURSE" text="CP: Kurs generieren"/>
+    <text name="input_CP_SET_POSITIONS_TO_VEHICLE" text="CP: Ziel &amp; Feld auf Fahrzeugposition setzen"/>
     <text name="input_CP_CHANGE_SELECTED_JOB" text="CP: Aktuell ausgewählten Job ändern"/>
     <text name="input_CP_CHANGE_STARTING_POINT" text="CP: Startpunkt ändern"/>
     <text name="input_CP_CLEAR_COURSE" text="CP: Aktuell geladenen Kurs löschen"/>

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -108,6 +108,8 @@
     <text name="CP_job_bunkerSilo" text="CP: Silo work"/>
     <text name="CP_job_siloLoader" text="CP: Silo loading"/>
     <text name="CP_ai_page_generate_course" text="CP: Generate fieldwork course"/>
+    <text name="CP_ai_page_positions_to_vehicle" text="Target &amp; field to vehicle"/>
+    <text name="CP_ai_page_positions_to_vehicle_title" text="Set positions"/>
     <text name="CP_ai_page_open_course_generator" text="CP: Open/close course generator"/>
     <!---->
     <!--AI error messages-->
@@ -1092,6 +1094,7 @@ Now your selection should look similar to the image.
     <text name="input_CP_START_STOP_AT_NEAREST_WAYPOINT" text="CP: Start/stop driver (at nearest waypoint)"/>
     <text name="input_CP_START_STOP_AT_LAST_WAYPOINT" text="CP: Start/stop driver (at last waypoint)"/>
     <text name="input_CP_GENERATE_COURSE" text="CP: Generate course"/>
+    <text name="input_CP_SET_POSITIONS_TO_VEHICLE" text="CP: Set target &amp; field to vehicle position"/>
     <text name="input_CP_CHANGE_SELECTED_JOB" text="CP: Change current selected job"/>
     <text name="input_CP_CHANGE_STARTING_POINT" text="CP: Change starting point"/>
     <text name="input_CP_CLEAR_COURSE" text="CP: Clear currently loaded course"/>


### PR DESCRIPTION
## Problem

When a job is created from the course generator page, the vehicle is usually already standing on the field, in position - but the target position and the field position still have to be picked on the map. That means two mouse picks for something the vehicle already knows, and it is easy to drop the field position on a neighbouring field or a headland of the wrong field.

## What this adds

A **Target & field to vehicle** button in the job parameter list, which sets the target position (including the direction the vehicle is facing) and the field/silo position to the vehicle's current position with one click.

![Set positions to vehicle button](https://raw.githubusercontent.com/helgehelge123/Courseplay_FS25/assets/docs/set-positions-to-vehicle.png)

Details:

* The button gets a group of its own right below the position parameters, so it can't be hit by accident while clicking the position rows.
* It is only added for jobs that actually have such a position: below the field/silo position if the job has one, otherwise below the target position (silo loader), and not at all for jobs with neither.
* It clones the position parameter template, so it looks, focuses and behaves exactly like the position rows above it (the `invalid` marker is hidden, it can't be invalid).
* After setting the positions, `validateParameters()` and `updateParameterValueTexts()` run, so the field boundary detection restarts for the new field position, just like after picking it manually.
* Positions that can't be changed (`getCanBeChanged()`) are left alone.

## Key binding

The same action is also available as a context button in the lower right corner, bound to a new rebindable input action `CP_SET_POSITIONS_TO_VEHICLE`, `KEY_v` by default. `KEY_v` is not used by any `MENU_*` action in the base game input bindings, it is only bound to vehicle and construction actions, which are not active while the menu is open.

The context button is only active while a job is being created and while nothing is being picked on the map, so the usual workflow can be done from the keyboard alone: <kbd>V</kbd> set the positions, <kbd>C</kbd> generate the course, <kbd>X</kbd> start the job.

That order is also the reason for the first commit in this PR: `getNumberOfItemsInSection()` built `contextActionMapping` by iterating `CONTEXT_ACTIONS` with `pairs()`. The table has integer keys, but they are assigned in the table constructor, so `pairs()` returns them in hash order and the context buttons could show up in any order. Using `ipairs()` makes the order deterministic and follows the order the actions are defined in.

Translations are added for English and German, other languages fall back to English.

## Testing

Tested in game with Courseplay 8.1.0.3 (screenshot above, German UI, bale collecting job): the button sets both positions to the vehicle position including its direction, the `V` key does the same, the button list keeps the intended order, and the button is not shown outside of job creation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
